### PR TITLE
Added edit link for documentation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,7 +42,7 @@ const config = {
           routeBasePath: '/',
           sidebarPath: './sidebars.js',
           editUrl:
-          'https://github.com/woocommerce/qit-documentation/tree/main',
+          'https://github.com/woocommerce/qit-documentation/tree/trunk',
         },
         blog: {
           routeBasePath: 'changelog',


### PR DESCRIPTION
This PR enables the "Edit this page" link on the documentation pages:

<img width="555" alt="Screenshot 2024-03-20 at 6 59 45 PM" src="https://github.com/woocommerce/qit-documentation/assets/71906536/663a4789-fcac-4997-9409-c0bb0da530ec">

To test:
- Checkout this branch
- Spin up the dev site with `npm run start`
- Open any page(s) in the documentation and verify clicking that page links to the corresponding page in GitHub. For example, on `http://localhost:3000/docs/workflows/getting-started` it should link to `https://github.com/woocommerce/qit-documentation/blob/trunk/docs/workflows/getting-started.md`.

Some caveats:

We should probably decide on making this repo public so anyone can edit these links, as right now it's restricted to if you have access. So, once we merge this, we should swap the repo and make sure we don't have any concerns with making that move.