### PR TITLE
Add initial shell of validation test documentation

### DIFF
--- a/docs/managed-tests/08-validation.md
+++ b/docs/managed-tests/08-validation.md
@@ -1,0 +1,16 @@
+# Validation Tests
+
+Our validation test is designed to inform you of any issues with plugin and theme metadata. Right now it is purely informative, but in the future it may block submissions or updates.
+
+## Types of Issues Flagged
+The presence and value of certain headers will be checked:
+
+- `Requires PHP` - warning if not present in main plugin or theme file.
+- More coming soon!
+
+## What to do if it fails
+
+If your validation test is failing, please review the following steps:
+- Open the test report.
+- Identify the causes of the failure (typically a missing or misspelled header) and remedy it.
+- If you believe you've run across a bug in the test, please email us at qit@woocommerce.com so we can review and make the necessary adjustments.

--- a/docs/support/test-options.md
+++ b/docs/support/test-options.md
@@ -6,14 +6,14 @@ sidebar_position: 1
 
 The table below shows what options are available for each test type. For example, for Activation tests you can supply a WordPress version but for the security tests it isn't supported.
 
-|                              | Activation | Woo E2E | Woo API | Security | PHPStan |
-| ---------------------------- | ---------- |---------|---------| -------- | ------- |
-| WordPress Versions           | ✅         | ✅       | ✅       | ❌       | ❌      |
-| WooCommerce Versions         | ✅         | ✅       | ✅       | ❌       | ❌      |
-| WooCommerce Features         | ✅         | ✅       | ✅       | ❌       | ❌      |
-| PHP Version                  | ✅         | ✅       | ✅       | ❌       | ❌      |
-| Additional Extensions        | ✅         | ✅       | ✅       | ❌       | ❌      |
-| Additional WordPress Plugins | ✅         | ✅       | ✅       | ❌       | ❌      |
+|                              | Activation | Woo E2E | Woo API | Security | PHPStan | Validation |
+| ---------------------------- | ---------- |---------|---------| -------- | ------- | ---------- |
+| WordPress Versions           | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
+| WooCommerce Versions         | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
+| WooCommerce Features         | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
+| PHP Version                  | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
+| Additional Extensions        | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
+| Additional WordPress Plugins | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
 
 ## WordPress and WooCommerce versions
 

--- a/src/components/TestTypes.js
+++ b/src/components/TestTypes.js
@@ -9,19 +9,21 @@ export default function TestTypes({ includeCode = false }) {
                 Managed Tests
                 <ul>
                     <li><a href="/docs/managed-tests/woo-e2e">Woo E2E Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:woo-e2e</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:woo-e2e</code></li>
                     <li><a href="/docs/managed-tests/woo-api">Woo API Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:woo-api</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:woo-api</code></li>
                     <li><a href="/docs/managed-tests/activation">Activation Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:activation</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:activation</code></li>
                     <li><a href="/docs/managed-tests/security">Security Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:security</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:security</code></li>
                     <li><a href="/docs/managed-tests/phpstan">PHPStan Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:phpstan</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:phpstan</code></li>
                     <li><a href="/docs/managed-tests/phpcompatibility">PHPCompatibility Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:phpcompatibility</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:phpcompatibility</code></li>
                     <li><a href="/docs/managed-tests/malware">Malware Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:malware</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:malware</code></li>
+                    <li><a href="/docs/managed-tests/validation">Validation Tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:validation</code></li>
                     <li>Performance Tests <i>(Coming soon)</i></li>
                 </ul>
             </li>
@@ -29,7 +31,7 @@ export default function TestTypes({ includeCode = false }) {
                 Custom Tests
                 <ul>
                     <li><a href="/docs/custom-tests/introduction">Custom E2E Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:e2e</code></li>
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:e2e</code></li>
                 </ul>
             </li>
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce.com/issues/21410

This adds a very rough shell of docs for the new validation test. In the future, we may expand the headers to a table instead of a list, for example, with columns for "should be present?" and "expected value".

Note - do not merge until we're ready to go live with the new test.