### PR TITLE
Proofreading pass

### DIFF
--- a/docs/cli/01-installation.md
+++ b/docs/cli/01-installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-The QIT CLI is a command line interface tool that allows you to run automated tests in the cloud against extensions available in the Woo Marketplace, powered by the QIT Test Runner.
+The QIT CLI is a command line interface tool that allows you to run automated tests in the cloud against extensions available in the WooCommerce Marketplace, powered by the QIT Test Runner.
 
 ![run-e2e](_media/run-e2e.png)
 
@@ -14,24 +14,24 @@ The QIT CLI is a command line interface tool that allows you to run automated te
 
 You can install QIT in three different ways:
 
-### Per Project
+### Per project
 
 1. Run `composer require woocommerce/qit-cli --dev`
-2. Execute `./vendor/bin/qit` to authenticate with your Woo.com Partner Developer account.
+2. Execute `./vendor/bin/qit` to authenticate with your WooCommerce.com Partner Developer account.
 
-### Globally Using Composer
+### Globally using Composer
 
 1. Run `composer global require woocommerce/qit-cli`
-2. Execute `qit` to authenticate with your Woo.com Partner Developer account. Ensure that the Composer bin folder is in your PATH. [Example](https://stackoverflow.com/a/64545124).
+2. Execute `qit` to authenticate with your WooCommerce.com Partner Developer account. Ensure that the Composer bin folder is in your PATH. [Example](https://stackoverflow.com/a/64545124).
 
-### Globally Using `wget`
+### Globally using `wget`
 
 _(Pro Tip: Opting for the Composer installation method simplifies the process of updating QIT in the future 😉)_
 
 1. Run `wget https://github.com/woocommerce/qit-cli/raw/trunk/qit`
 2. Execute `chmod +x qit`
 3. Move the file to a directory in your PATH, such as `sudo mv qit /usr/local/bin/qit`
-4. Run `qit` to authenticate with your Woo.com Partner Developer account.
+4. Run `qit` to authenticate with your WooCommerce.com Partner Developer account.
 
 ## Updating QIT
 

--- a/docs/cli/04-scripting.md
+++ b/docs/cli/04-scripting.md
@@ -2,7 +2,7 @@
 
 QIT CLI allows you to create robust scripts that can optimize your development workflow. Here is an example of a bash script used for authentication and running tests against a development build.
 
-### Directory Structure
+### Directory structure
 
 For this example, we will assume the following directory structure. This can be in the same folder where you develop your plugin or in its own directory:
 
@@ -11,7 +11,7 @@ For this example, we will assume the following directory structure. This can be 
 - vendor/bin/qit
 - build/extension.zip _(Assuming this is created by `npm run build`)_
 
-### Environment Variables (.env)
+### Environment variables (.env)
 
 Create a `.env` file in the root directory of your project and add your QIT user and application password:
 
@@ -20,7 +20,7 @@ QIT_USER=foo
 QIT_APP_PASS=bar
 ```
 
-### Bash Script (bin/qit.sh)
+### Bash script (bin/qit.sh)
 
 This script authenticates the QIT_USER and then runs security tests against the extension build. If the 'partner:remove' command is not available, it adds a partner using `QIT_USER` and `QIT_APP_PASSWORD`. For more information on how authentication works with QIT, see our [documentation around authentication](https://woocommerce.github.io/qit-documentation/#/authenticating).
 
@@ -59,7 +59,7 @@ if [ $? -ne 0 ]; then
 fi
 ```
 
-### Script Runner (Choose between NPM, Composer, Make)
+### Script runner (Choose between NPM, Composer, Make)
 
 Script runners can be used to execute our bash script `qit.sh`. You can choose the script runner that best suits your needs. Below you can find some examples we've put together for NPM, Composer, and Make.
 

--- a/docs/cli/05-github-workflows.md
+++ b/docs/cli/05-github-workflows.md
@@ -6,7 +6,7 @@ For more information on how [GitHub Actions](https://docs.github.com/en/actions)
 
 The examples below can be tweaked based on your needs, and use a fictional `woocommerce-product-feeds` extension to run the tests against. There's a few [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) that need to be configured for this flow (feel free to rename these to whatever makes the most sense for you and your team):
 
-- `PARTNER_USER`: Your Woo.com username.
+- `PARTNER_USER`: Your WooCommerce.com username.
 - `PARTNER_SECRET`: Your [WordPress Application Password](https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/).
 
 ## Activation test example

--- a/docs/custom-tests/00-introduction.md
+++ b/docs/custom-tests/00-introduction.md
@@ -1,10 +1,10 @@
 # Introduction
 
 :::info
-The Custom Tests feature is available as early-access.
+The custom tests feature is available as early-access.
 :::
 
-The Custom E2E tests allows you to easily write and share E2E tests with other developers.
+The custom E2E tests allows you to easily write and share E2E tests with other developers.
 
 It provides you with a dockerized development environment, and a ready-to-go example test that you can run with one command.
 
@@ -12,13 +12,13 @@ Customize the test to your needs, then share it with other developers, or run it
 
 Or, just use one of our pre-built generic tests to get you started. (Coming soon)
 
-## The Power of Customization: `run:e2e`
+## The power of customization: `run:e2e`
 
-While QIT provides various managed tests, Custom E2E tests stand out as the sole category where you, the developer, are the architect of the tests. These are not just any tests; they are comprehensive end-to-end tests designed to ensure your plugin's custom behavior functions flawlessly in real-world scenarios.
+While QIT provides various managed tests, custom E2E tests stand out as the sole category where you, the developer, are the architect of the tests. These are not just any tests; they are comprehensive end-to-end tests designed to ensure your plugin's custom behavior functions flawlessly in real-world scenarios.
 
-## Case Study: "QIT the Beaver" Tackles Plugin Challenges
+## Case study: "QIT the Beaver" tackles plugin challenges
 
-Imagine "QIT the Beaver," our beloved mascot, stepping into a developer's shoes. He launches a plugin on the Woo.com Marketplace, and while it initially receives high praise, soon users report issues related to compatibility and conflicts with other plugins and PHP versions.
+Imagine "QIT the Beaver," our beloved mascot, stepping into a developer's shoes. He launches a plugin on the WooCommerce.com Marketplace, and while it initially receives high praise, soon users report issues related to compatibility and conflicts with other plugins and PHP versions.
 
 > ⭐⭐⭐⭐⭐ Works great
 > 
@@ -38,8 +38,7 @@ What does _QIT the Beaver_ do? Even though he tries very hard, he can't possibly
 
 To bring some peace of mind, he finally decides it's time to write some end-to-end tests.
 
-
-### Generating the Tests
+### Generating the tests
 
 So he pulls up the QIT CLI and runs:
 
@@ -65,7 +64,7 @@ Then he runs the tests and sees them running in a browser:
 qit run:e2e qit-the-beaver ./e2e --ui
 ```
 
-### Publishing the Tests
+### Publishing the tests
 
 Satisfied with the results, Beaver decides it's showtime. He uploads the tests to QIT’s platform, a move that simplifies future test runs:
 
@@ -95,7 +94,7 @@ qit run:e2e qit-the-beaver \
 
 This comprehensive command allows him to test with PHP 8.3, the latest WordPress release candidate, the nightly WooCommerce version, and alongside popular plugins and themes.
 
-### Running Tests from Different Plugins
+### Running tests from different plugins
 
 The maker of `Cat Pictures` also uploaded their tests to QIT, which means that QIT the Beaver can integrate the tests from the "Cat Pictures" plugin in his test runs. This is done by passing the plugin slug to the `--plugin` flag:
 

--- a/docs/custom-tests/01-generating-tests.md
+++ b/docs/custom-tests/01-generating-tests.md
@@ -1,7 +1,7 @@
-# Generating Tests
+# Generating tests
 
 :::info
-The Custom Tests feature is available as early-access.
+The custom tests feature is available as early-access.
 :::
 
 ## Introduction
@@ -55,7 +55,7 @@ It essentially records your interactions with the browser and generates the code
 When you generate tests with `--codegen`, they will be generated with the URLs you visited during the recording, eg:
 
 
-#### How Codegen Generates It:
+#### How Codegen generates it:
 
 ```js
 await page.goto('http://localhost:32456');
@@ -66,7 +66,7 @@ await page.goto('http://localhost:32456/wp-admin');
 
 After pasting it in a test file, remove the URLs, as the test run uses a `baseURL`.
 
-#### How it should look like in your test file:
+#### How it should look in your test file:
 
 ```js
 await page.goto('/');
@@ -75,7 +75,7 @@ await page.goto('/my-page');
 await page.goto('/wp-admin');
 ```
 
-## Using QIT Helpers
+## Using QIT helpers
 
 We have a set of helpers that you can use in your tests to make your life easier. You can find them in the QIT Helpers documentation _(Coming soon)_.
 

--- a/docs/custom-tests/02-tagging-tests.md
+++ b/docs/custom-tests/02-tagging-tests.md
@@ -1,4 +1,4 @@
-# Tagging Tests
+# Tagging tests
 
 :::info
 The Custom Tests feature is available as early-access.
@@ -24,7 +24,7 @@ To list the test tags for a specific plugin/theme:
 qit tag:list qit-beaver
 ```
 
-## Uploading Tests
+## Uploading tests
 
 You can upload your tests and make them available as a tag with the command:
 
@@ -40,7 +40,7 @@ If you want to specify a test tag, you can add the tag in this format: `extensio
 qit tag:upload qit-beaver:my-tag /path/to/tests
 ```
 
-## Running Test Tags
+## Running test tags
 
 Now you can run your test both locally and in CI using the `default` tag:
 
@@ -54,7 +54,7 @@ Or, if it's a specific tag:
 qit run:e2e qit-beaver my-tag
 ```
 
-## Running Test Tags from Other Plugins
+## Running test tags from other plugins
 
 Other developers that have access to your extension can also use your tests for compatibility testing.
 
@@ -64,7 +64,7 @@ Let's suppose that `qit-dog` has published their tests. You can run your tests a
 qit run:e2e qit-beaver --plugin qit-dog:test
 ```
 
-## Running Multiple Tags
+## Running multiple tags
 
 You can also compose multiple tags by passing a comma-separated list of test tags:
 
@@ -72,7 +72,7 @@ You can also compose multiple tags by passing a comma-separated list of test tag
 qit run:e2e qit-beaver default,rc --plugin qit-dog:test:feature-dog-pictures
 ```
 
-## Deleting Test Tags
+## Deleting test tags
 
 You can delete test tags that you have previously published:
 

--- a/docs/custom-tests/03-running-tests.md
+++ b/docs/custom-tests/03-running-tests.md
@@ -1,13 +1,13 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Running Tests
+# Running tests
 
 :::info
-The Custom Tests feature is available as early-access.
+The custom tests feature is available as early-access.
 :::
 
-## Running a Basic Test
+## Running a basic test
 
 Assuming you have generated and uploaded a E2E test, the basic syntax for running a test is:
 
@@ -25,7 +25,7 @@ qit run:e2e qit-beaver ~/my-plugins/qit-beaver/tests
 Replace "qit-beaver" with the slug of an extension you own.
 :::
 
-## Using a Config File
+## Using a config file
 
 Place a `qit-env.json` or `qit-env.yml` file in the directory you run `qit run:e2e` from.
 
@@ -102,7 +102,7 @@ plugins:
 
 </Tabs>
 
-## Using Parameters
+## Using parameters
 
 You can also mimick this entire config file using only runtime parameters.
 
@@ -118,7 +118,7 @@ qit run:e2e qit-the-beaver ~/my-plugins/qit-beaver/tests --source ~/.qit/plugins
   --plugin https://github.com/qit-plugins/qit-dog/releases/tag/nightly.zip:test:nightly,feature-dog-pictures:qit-dog
 ```
 
-## The Plugin Syntax
+## The plugin syntax
 
 As you can see, defining how a plugin should be used in our test can be complex, as we need to account for different ways to use it.
 
@@ -130,14 +130,14 @@ qit run:e2e <main-extension> --plugin <plugin-syntax>
 
 Where:
 
-- `source` can be a slug, a Zip URL, a local path, or a Woo.com ID.
+- `source` can be a slug, a Zip URL, a local path, or a WooCommerce.com ID.
 - `action` can be `activate`, `bootstrap` or `test` (default is `bootstrap`. They are cumulative, so if you pass `test`, it will also activate and bootstrap the plugin)
 - `test-tags` is a comma-separated list of test tags to run, or a local directory (default is `default`)
 - `slug` is the plugin slug. This is only needed if using a `source` other than a slug, and the slug can't be inferred.
 
 ### Inferring `slug` from `source`
 
-If you are using a local path, a Zip URL, or a Woo.com ID, we will try to infer the `slug` from the basename of the file or directory.
+If you are using a local path, a Zip URL, or a WooCommerce.com ID, we will try to infer the `slug` from the basename of the file or directory.
 
 Examples:
 

--- a/docs/custom-tests/04-running-other-plugins-tests.md
+++ b/docs/custom-tests/04-running-other-plugins-tests.md
@@ -1,7 +1,7 @@
-# Running Tests from Other Plugins
+# Running tests from other plugins
 
 :::info
-The Custom Tests feature is available as early-access.
+The custom tests feature is available as early-access.
 :::
 
 ## Introduction
@@ -10,7 +10,7 @@ You can run tests from other plugins that you have access to.
 
 This is useful for compatibility testing, or to run tests that are not part of your plugin, such as getting cheap coverage for your own plugin by leveraging tests that are already written.
 
-## Running a Test from Another Plugin
+## Running a test from another plugin
 
 To run a test from another plugin, you can use the `--plugin` flag:
 
@@ -30,7 +30,7 @@ qit run:e2e qit-beaver --plugin cat-pictures:test
 
 Now the test phases of both plugins are run. This is useful for ensuring that your plugin does not break the expected behavior of other plugins.
 
-## Discovering Available Tests
+## Discovering available tests
 
 You can see all the test tags you have access to by running:
 
@@ -51,7 +51,7 @@ This will print a table like this:
 
 This table shows the available test tags for each plugin. You can use these tags to run specific tests.
 
-## Compositing Tests
+## Compositing tests
 
 You can run multiple tests by passing a comma-separated list of tags:
 

--- a/docs/custom-tests/05-bootstrap-and-test-phases.md
+++ b/docs/custom-tests/05-bootstrap-and-test-phases.md
@@ -2,10 +2,10 @@ import CustomTestsDiagram from '@site/src/img/custom-tests-diagram.png';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Bootstrap and Test Phases
+# Bootstrap and test phases
 
 :::info
-The Custom Tests feature is available as early-access.
+The custom tests feature is available as early-access.
 :::
 
 ## Introduction
@@ -16,7 +16,7 @@ This is the flow of execution:
 
 <img src={CustomTestsDiagram}/>
 
-## The Bootstrap Phase
+## The bootstrap phase
 
 In this phase, set up everything your tests needs, and do the initial setup of your plugin.
 
@@ -47,7 +47,7 @@ This is a file that, if present, will be copied to the `wp-content/mu-plugins` d
 
 If you want to put logic in there that should run only once, make sure to set a flag to prevent it from running multiple times.
 
-### Where to Put the Bootstrap Files
+### Where to put the bootstrap files
 
 Place them in the bootstrap directory within your E2E test suite. Here’s how your directory structure should look:
 
@@ -76,11 +76,11 @@ example.spec.js
 └── qit-beaver.php                   # Main plugin file
 ```
 
-## The Entrypoint
+## The entrypoint
 
 The `entrypoint.spec.js` is a file that, if present, will be called when your **Test Phase** starts. This is a good place to put any setup logic, such as **activating** a theme that you have previously **installed** in the Bootstrap Phase.
 
-## The Test Phase
+## The test phase
 
 This is where the actual testing happens. We utilize Playwright to interact with the browser and verify your plugin's functionality. By default, the only test phase that gets executed is the one from the plugin you are running the tests from.
 
@@ -88,14 +88,14 @@ This is where the actual testing happens. We utilize Playwright to interact with
 When running with the test phase of other plugins, any flakiness in the tests of other plugins can cause your tests to fail.
 :::
 
-### E2E Test
+### E2E test
 
 If you run this command: `qit run:e2e qit-the-beaver --plugin cat-pictures`:
 
 - Run the bootstrap phases of all the plugins
 - **Run the test phase of `qit-the-beaver`**
 
-### Compatibility Test
+### Compatibility test
 
 If instead you want to run a full compatibility test, you can run, `qit run:e2e qit-the-beaver --plugin cat-pictures:test`, it will:
 

--- a/docs/custom-tests/06-themes.md
+++ b/docs/custom-tests/06-themes.md
@@ -1,14 +1,14 @@
 # Themes
 
 :::info
-The Custom Tests feature is available as early-access.
+The custom tests feature is available as early-access.
 :::
 
 ## Introduction
 
 You can use the Custom Tests to test both plugins and themes.
 
-## Using a specific Theme on your Tests
+## Using a specific theme on your tests
 
 If you are developing a plugin, and you write E2E tests that interact with the front-end, you will want to make sure that a specific theme is active when the tests run.
 
@@ -41,7 +41,7 @@ test('I can activate my theme', async ({ page }) => {
 
 This entrypoint was generated with Codegen. The easiest way is to start a codegen session, activate the theme, and use the generated code on your entrypoint.
 
-## Testing a Theme
+## Testing a theme
 
 If you are developing a theme, the previous section applies as well. And when you run it, be sure to add the `--testing_theme` flag:
 

--- a/docs/custom-tests/07-security.md
+++ b/docs/custom-tests/07-security.md
@@ -1,14 +1,14 @@
-# The Security Architecture of the Custom Tests
+# The security architecture of the custom tests
 
 :::info
-The Custom Tests feature is available as early-access.
+The custom tests feature is available as early-access.
 :::
 
-## Containerized Test Environments
+## Containerized test environments
 
-All test code runs only on containerized Docker Environments meticulously designed for maximum isolation. This advanced engineering at both high and low levels guarantees that the test code execution remains completely segregated from the rest of the system.
+All test code runs only on containerized Docker environments meticulously designed for maximum isolation. This advanced engineering at both high and low levels guarantees that the test code execution remains completely segregated from the rest of the system.
 
-Every volume mount was carefully considered, and by default, only the directories within the disposable test directory are mounted into the Docker Environments. The only exception is if you choose to mount additional volumes with the `--volumes` parameter or config file, in which case the volumes will be mounted in read-only mode.
+Every volume mount was carefully considered, and by default, only the directories within the disposable test directory are mounted into the Docker environments. The only exception is if you choose to mount additional volumes with the `--volumes` parameter or config file, in which case the volumes will be mounted in read-only mode.
 
 The tests are executed as a non-root user, defaulting to UID/GID of your currently logged-in user.
 

--- a/docs/custom-tests/_category_.json
+++ b/docs/custom-tests/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Custom Tests",
+    "label": "Custom tests",
     "position": 4,
     "link": {
         "type": "generated-index"

--- a/docs/environment/01-getting-started.md
+++ b/docs/environment/01-getting-started.md
@@ -2,15 +2,15 @@
 sidebar_position: 1
 ---
 
-# Local Test Environment
+# Local test environment
 
 :::info
-The Local Test Environment is available as early-access.
+The local test environment is available as early-access.
 :::
 
 ## Introduction
 
-The QIT Local Test Environment was engineered to do one thing, and one thing well: Running Automated Tests.
+The QIT local test environment was engineered to do one thing, and one thing well: running automated tests.
 
 It allows you to create a local WordPress environment with a single command. These environments are disposable, meaning that whatever changes you do in it do not persist across runs. So if you do `qit env:up`, and you delete the database of that site entirely, and then do `qit env:up` again, you will get a fresh new site with no trace of the previous one.
 
@@ -21,17 +21,17 @@ Before you begin, ensure that you have the following prerequisites installed:
 - **QIT CLI**: If you haven't already installed the QIT CLI tool, follow the instructions in the [Installation Guide](cli/01-installation.md).
 - **Docker**: QIT relies on Docker for creating isolated environments. Make sure Docker is installed and running on your system. [Download Docker here](https://www.docker.com/get-started).
 
-### Getting Started - Mac
+### Getting started - Mac
 
 Assuming you have [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/) or [OrbStack](https://orbstack.dev/) installed, you can start using the QIT Local Test Environment right away. For the best experience, we recommend OrbStack, as it can be **much faster** than Docker Desktop.
 
-### Getting Started - Linux
+### Getting started - Linux
 
 Assuming you have Docker, preferably the most up-to-date version, with Composer V2, you can start using the QIT Local Test Environment right away.
 
-### Getting Started - Windows
+### Getting started - Windows
 
-The QIT Local Test Environment works on Mac and Linux natively, but for Windows, **you have to use Windows WSL**. 
+The QIT local test environment works on Mac and Linux natively, but for Windows, **you have to use Windows WSL**. 
 
 - Use WSL 2, as it is faster and easier to install than WSL 1.
 - On the latest version of Windows, simply open PowerShell and run `wsl --install`
@@ -47,7 +47,7 @@ Creating a local test environment with QIT is straightforward:
 2. Access your site at the URL provided.
 3. `qit env:down` and the environment is gone.
 
-## Customizing Your Environment
+## Customizing your environment
 
 Now let's spin up a customized local test environment with a few options:
 
@@ -61,7 +61,7 @@ qit env:up \
 
 This will create an environment with PHP 8.3 on WordPress RC version, with Gutenberg, and Contact Form 7.
 
-## Using Configuration Files
+## Using configuration files
 
 Create a `qit-env.yml` file in your project directory with the following content:
 
@@ -75,7 +75,7 @@ plugins:
 
 Now you just do `qit env:up`, without any additional parameters, and you get the same environment as before, as well as anyone on your team.
 
-## Managing Environments
+## Managing environments
 
 - **env:up**: Creates a Local Test Environment
 - **env:down**: Stops a running local test environment.
@@ -83,7 +83,7 @@ Now you just do `qit env:up`, without any additional parameters, and you get the
 - **env:enter**: Enters the PHP container of a running test environment.
 - **env:exec**: Execute a command inside the PHP container.
 
-## `env:up` Options
+## `env:up` options
 
 - **--wordpress_version**: Choose the specific version of WordPress for your test environment.
 - **--php_version**: Test your project with different PHP versions to ensure compatibility.

--- a/docs/environment/02-creating-config-files.md
+++ b/docs/environment/02-creating-config-files.md
@@ -1,21 +1,21 @@
-# Creating Configuration Files
+# Creating configuration files
 
 :::info
-The Local Test Environment is available as early-access.
+The local test environment is available as early-access.
 :::
 
 ## Introduction
 
 In the QIT Local Test Environment, configuration files are a powerful way to predefine and standardize environment settings. This guide explains how to create and use JSON or YAML configuration files for your testing environments.
 
-## Creating a Configuration File
+## Creating a configuration file
 
-### 1. File Format
+### 1. File format
 
 - **JSON or YAML**: You can create configuration files in either JSON or YAML format.
 - **Naming**: Name your file `qit-env.json` or `qit-env.yml`. For overrides, use `qit-env.override.json` or `qit-env.override.yml`.
 
-### 2. Configuration Options
+### 2. Configuration options
 
 Include any of the following options in your configuration file:
 - `wordpress_version`: Specify the version of WordPress.
@@ -26,7 +26,7 @@ Include any of the following options in your configuration file:
 - `php_extensions`: List any PHP extensions needed.
 - `object_cache`: Enable or disable Redis Object Cache.
 
-### 3. Example Configurations
+### 3. Example configurations
 
 **JSON Example**:
 ```json
@@ -68,7 +68,7 @@ php_extensions:
 object_cache: true
 ```
 
-## Using Configuration Files
+## Using configuration files
 
 1. **Place the File**: Put your configuration file in the root of your project directory, or in the directory where you run QIT commands.
 2. **Run QIT**: When you start QIT (`qit env:up`), it automatically detects the config file in the current directory and applies settings from your configuration file.

--- a/docs/environment/03-installing-plugins-and-themes.md
+++ b/docs/environment/03-installing-plugins-and-themes.md
@@ -1,31 +1,31 @@
-# Installing Plugins and Themes
+# Installing plugins and themes
 
 :::info
-The Local Test Environment is available as early-access.
+The local test environment is available as early-access.
 :::
 
 ## Introduction
 
 When starting an environment you can choose to install different plugins and themes with `--plugin`, `--themes` or through the config files.
 
-You can install any plugins from WordPress.org, and any plugins from Woo.com that you have access to.
+You can install any plugins from WordPress.org, and any plugins from WooCommerce.com that you have access to.
 
 If you are running a custom E2E test with `qit run:e2e`, it will also download their custom tests, if they have any registered in QIT.
 
 
-## Testing Premium Plugins
+## Testing premium plugins
 
-Authentication to download premium plugins listed on Woo.com are automatically handled for you based on your Partner Developer credentials.
+Authentication to download premium plugins listed on WooCommerce.com is automatically handled for you based on your Partner Developer credentials.
 
-Currently, you can download premium plugins and tests from plugins you own on Woo.com, and we are exploring ways of allowing
+Currently, you can download premium plugins and tests from plugins you own on WooCommerce.com, and we are exploring ways of allowing
 plugin developers to optionally allow other Partner Developers access to their plugins and tests to encourage compatibility testing.
 
-While QIT is a Woo.com exclusive for now, you can only download custom tests for plugins that are listed in the Woo.com Marketplace.
+While QIT is a WooCommerce.com exclusive for now, you can only download custom tests for plugins that are listed in the WooCommerce.com Marketplace.
 
-## Installing Premium Plugins from Other Sources
+## Installing premium plugins from other sources
 
 While you cannot download custom tests from other sources, you can download the plugins and install them in your environment.
 
-You can do this by implementing a Custom Handler, which gives you total control over where to fetch your plugin files from.
+You can do this by implementing a custom handler, which gives you total control over where to fetch your plugin files from.
 
 Read more about it on the next section.

--- a/docs/environment/04-installing-plugins-other-sources.md
+++ b/docs/environment/04-installing-plugins-other-sources.md
@@ -1,34 +1,34 @@
-# Installing Plugins and Themes From Other Sources
+# Installing plugins and themes from other sources
 
 :::info
-The Local Test Environment is available as early-access.
+The local test environment is available as early-access.
 :::
 
 ## Introduction
 
-The QIT Local Test Environment offers the flexibility to install plugins and themes from various sources, including private repositories. This guide outlines the process for extending your environment with these external resources.
+The QIT local test environment offers the flexibility to install plugins and themes from various sources, including private repositories. This guide outlines the process for extending your environment with these external resources.
 
-## Implementing Custom Handlers
+## Implementing custom handlers
 
-### Understanding Custom Handlers
+### Understanding custom handlers
 
 Custom handlers allow QIT to integrate with external sources for plugin and theme installation. They are particularly useful for fetching extensions from premium marketplaces or private repositories that QIT does not support natively.
 
-### Creating a Custom Handler
+### Creating a custom handler
 
 - **Extend the CustomHandler Class**: Create a new class that extends the `CustomHandler` abstract class provided by QIT.
 - **Implement Required Methods**: Your custom handler must implement methods like `should_handle`, `populate_extension_versions`, and `maybe_download_extensions`.
 - **Use the Custom Handler**: Include your custom handler file using the `--require` flag when starting QIT. For example, `qit env:up --require=my-custom-handler.php`.
 
-### Example Custom Handlers
+### Example custom handlers
 
 You can get really creative with this, and essentially do anything you want. Here are a few examples to get you started:
 
-#### Example 1: Fetching from a Public GitHub Repository
+#### Example 1: fetching from a public GitHub repository
 
 This example assumes that you have a public GitHub repository and want to use it as a plugin in your environment.
 
-We assume for simplicity purposes, that the GitHub Repository is a WordPress plugin, and that it has a `main` branch.
+We assume for the purposes of simplicity that the GitHub pepository is a WordPress plugin, and that it has a `main` branch.
 
 Example command: `qit env:up --requires=public-handler.php --plugins=my-public-plugin`
 
@@ -85,7 +85,7 @@ class PublicHandlerExample extends CustomHandler {
 
 In this example, we will clone our public repo to a temp directory, create a zip of it and use the zip as a plugin in our environment.
 
-#### Example 2: Fetching from a Private GitHub Repository
+#### Example 2: fetching from a private GitHub repository
 
 This example is similar to the previous one, but it assumes that the GitHub repository is private and requires authentication.
 
@@ -160,7 +160,7 @@ class PrivateGitHubHandler extends CustomHandler {
 }
 ```
 
-#### Example 3: Fetching from a Private GitHub Repository, building it, and caching the build file
+#### Example 3: Fetching from a private GitHub repository, building it, and caching the build file
 
 You can get really creative with custom handlers. In this example, we will:
 
@@ -312,7 +312,7 @@ class AdvancedGitHubHandler extends CustomHandler {
 }
 ```
 
-## Using the Custom Handler
+## Using the custom handler
 
 Once you have implemented your custom handler, you can use it by including it with the `--requires` option in the QIT command. Your handler will then be invoked for any plugins or themes that meet its handling criteria, eg:
 
@@ -345,7 +345,7 @@ requires:
   - my-custom-handler.php
 ```
 
-### Using Multiple Custom Handlers
+### Using multiple custom handlers
 
 You can use multiple custom handlers by including them in your config files, or at runtime with the `--requires` option in the QIT command. For example:
 
@@ -364,10 +364,10 @@ requires:
 
 When you run `qit:up`, QIT will use the custom handlers to fetch the plugins and themes from the specified sources.
 
-## Tips and Best Practices
+## Tips and best practices
 
-- **Test Your Handler**: Ensure your custom handler works as expected in various scenarios.
-- **Handle Dependencies**: If your plugin or theme has dependencies, ensure your handler can resolve them.
+- **Test your handler**: Ensure your custom handler works as expected in various scenarios.
+- **Handle dependencies**: If your plugin or theme has dependencies, ensure your handler can resolve them.
 - **Security**: Always consider security implications when fetching from external sources.
 
 ## Support

--- a/docs/environment/_category_.json
+++ b/docs/environment/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Local Test Environment",
+    "label": "Local test environment",
     "position": 5,
     "link": {
         "type": "generated-index"

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -9,7 +9,7 @@ import QITImageURL from '@site/static/img/qit-right.webp';
 
 # What is QIT?
 
-QIT is a testing platform for WordPress Plugins and Themes developed by WooCommerce that allows developers to run a series of managed tests out-of-the-box. We are currently in closed beta operating only in the [Woo Marketplace](https://woo.com/products/) .
+QIT is a testing platform, developed by WooCommerce, for WordPress plugins and themes that allows developers to run a series of managed tests out-of-the-box. It is currently in closed beta operating only in the [WooCommerce Marketplace](https://woocommerce.com/products/) .
 
 <video controls style={{ width:"100%", height:"100%" }}>
     <source src={QITIntro} type="video/mp4"/>
@@ -29,26 +29,26 @@ QIT is a testing platform for WordPress Plugins and Themes developed by WooComme
 
 ## Requirements
 
-Currently, to use QIT you need to have at least one extension listed on the Woo.com Marketplace.
+Currently, to use QIT you need to have at least one extension listed on the WooCommerce.com Marketplace.
 
 ## Quick Start Guide
 
 1. `composer require woocommerce/qit-cli --dev`
-2. `./vendor/bin/qit connect` to generate a QIT Token and [authenticate](/docs/support/authenticating) using your Woo.com developer account.
-4. `./vendor/bin/qit run:activation your-extension`, where "your-extension" is the slug of a Woo.com extension you own.
+2. `./vendor/bin/qit connect` to generate a QIT Token and [authenticate](/docs/support/authenticating) using your WooCommerce.com developer account.
+4. `./vendor/bin/qit run:activation your-extension`, where "your-extension" is the slug of a WooCommerce.com extension you own.
 
 ## What types of tests are available?
 
 <TestTypes />
 
-## QIT and the Woo.com Marketplace
-QIT automatically runs tests for every new release on the Woo Marketplace. Additionally, Partner Developers can
+## QIT and the WooCommerce.com Marketplace
+QIT automatically runs tests for every new release on the WooCommerce Marketplace. Additionally, Partner Developers can
 run tests on-demand using our CLI tool.
 
-## Can I use QIT if I'm not a Developer on Woo.com?
-While the full QIT is exclusive to Woo.com Partner Developers, non-partners can use the local test environment. Full access is planned for the public in the future.
+## Can I use QIT if I'm not a Developer on WooCommerce.com?
+While the full QIT is exclusive to WooCommerce.com Partner Developers, non-partners can use the local test environment. Full access is planned for the public in the future.
 
 ## Ways to Use QIT
 - **CLI**: For running and viewing tests, including development builds. [Getting Started with CLI](cli/01-installation.md).
-- **Dashboard**: UI-based test runner and results viewer in your Woo.com dashboard. [Dashboard Guide](woo-com/getting-started).
+- **Dashboard**: UI-based test runner and results viewer in your WooCommerce.com dashboard. [Dashboard Guide](woo-com/getting-started).
 - **GitHub Workflows**: To integrate QIT tests in GitHub development workflows. [Setting Up Workflows](cli/05-github-workflows.md).

--- a/docs/managed-tests/00-introduction.md
+++ b/docs/managed-tests/00-introduction.md
@@ -1,17 +1,17 @@
 import TestTypes from '@site/src/components/TestTypes';
 
-# Managed Tests
+# Managed tests
 
-Managed Tests are a series of tests written and maintained by QIT.
+Managed tests are a series of tests written and maintained by QIT.
 
 All of these tests are available for you out-of-the-box, and they work with any WordPress plugin or theme.
 
 <TestTypes />
 
-## Managed Tests vs. Custom Tests
+## Managed tests vs. custom tests
 
-While the Managed Tests are written and maintained by us, the Custom Tests are written and maintained by you.
+While the managed tests are written and maintained by us, the custom tests are written and maintained by you.
 
-The Managed Tests are designed to cover the most common use cases and scenarios, but they may not cover all the specific use cases of your plugin or theme.
+The managed tests are designed to cover the most common use cases and scenarios, but they may not cover all the specific use cases of your plugin or theme.
 
-If you have specific use cases that are not covered by the Managed Tests, you can write your own Custom Tests and run them using QIT.
+If you have specific use cases that are not covered by the managed tests, you can write your own custom tests and run them using QIT.

--- a/docs/managed-tests/01-woo-e2e.md
+++ b/docs/managed-tests/01-woo-e2e.md
@@ -1,4 +1,4 @@
-# Woo E2E Tests
+# Woo E2E tests
 
 The Woo end-to-end (e2e) test creates a temporary WordPress installation with WooCommerce and the extension under test installed, and uses a browser that is scripted to perform certain automated tasks, such as completing the WooCommerce onboarding wizard, creating a product, making a purchase as a customer, verifying the order details as an admin, tweaking tax settings, etc.
 
@@ -27,7 +27,7 @@ If your end-to-end test is failing, please take the following steps:
 - If the test continues to fail, it can be either because of a bug that should be fixed, or because your extension modifies the default WooCommerce behavior in a way that is unexpected by the automated tests. 
 - We expect a certain amount of extensions to fail the end-to-end tests because they modify WooCommerce behaviors in ways that the tests are not designed to account for, such as modifying HTML selectors, etc. If you believe that is the case with your extension, please email us at qit@woocommerce.com and we can help you determine the best way to proceed, by either adapting the tests, suggesting some tweaks to your plugin, or by ignoring some tests especifically for your plugin.
 
-## Understanding Allure Reports
+## Understanding Allure reports
 
 For end-to-end test failures, an Allure test report will be generated and is available on the [All Test page](../woo-com/viewing-test-results.md). Allure reports provide a lot of great information to help troubleshoot and diagnose any test failures. For failures, screenshots and a stacktrace is provided. This section provides an overview of a report and where to go to view results. For a more detailed overview, see the official Allure documentation under [Report Structure](https://docs.qameta.io/allure-report/#_report_structure).
 

--- a/docs/managed-tests/02-woo-api.md
+++ b/docs/managed-tests/02-woo-api.md
@@ -1,4 +1,4 @@
-# Woo API Tests
+# Woo API tests
 
 API Testing is a crucial part of ensuring the smooth functioning of an application. With Woo API testing, we execute a set of operations using the [WooCommerce REST API](https://woocommerce.github.io/woocommerce-rest-api-docs/) and verify that the API responds in an expected, consistent, way. These operations include creating products, customers, and orders through the REST API and then validating the data that we have created.
 

--- a/docs/managed-tests/04-security.md
+++ b/docs/managed-tests/04-security.md
@@ -1,4 +1,4 @@
-# Security Tests
+# Security tests
 
 This test runs an experimental security scanner against a given extension.
 
@@ -6,22 +6,22 @@ This test runs an experimental security scanner against a given extension.
 - Warning: Only security issues warnings.
 - Failure: One or more security issues errors.
 
-### What Tools Are Used?
+### What tools are used?
 The tools used in the Security Scanner are, currently, [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) and [SemGrep](https://semgrep.dev/).
 
-### Can I run it Locally?
+### Can I run it locally?
 Ideally, you should delegate all the testing execution to QIT. We don't support running the tests outside of QIT, but you can mimick at least the PHPCS rules. The SemGrep rules are not available to be run locally.
 
-### Which PHPCS Rules Are Enabled?
+### Which PHPCS rules are enabled?
 We use the WordPress Coding Style Standards project. Apart from SemGrep, the Security Tests runs all rules of the `WordPress.Security` namespace, and of `WordPress.DB`.
 
-## What to do When Encountering a Discouraged Function?
+## What to do when encountering a discouraged function?
 
 We identify functions that may lead to potential security vulnerabilities and mark them with a Warning using the `Generic.PHP.ForbiddenFunctions.Discouraged` rule.
 
 While these functions are not inherently unsafe, they frequently contribute to critical vulnerabilities. We flag them to encourage you to review the code for security. If you've confirmed that the code is secure, you can suppress the warning by adding the following comment on the same line as the function: `// phpcs:ignore Generic.PHP.ForbiddenFunctions.Discouraged`
 
-## What to do if it Fails
+## What to do if it fails
 
 If your security test is failing, please take the following steps:
 - Open the test report
@@ -40,7 +40,7 @@ After a few minutes, this will generate a report of suggested fixes for the resu
 Our AI-assisted recommendations are still in the early stages of training, so it is expected that it produces some invalid suggestions. **Please use these suggestions carefully.** We trained this model on a large dataset of insecure and secure code, specializing it to convert insecure code into secure code. Your help to train this AI is paramount. Please provide feedback about the suggestions, your feedback is used to constantly improve the models.
 :::
 
-### Handling False Positives
+### Handling false positives
 
 False positives, or alerts for security issues that do not exist in actuality, may occasionally arise during security testing. Though we've chosen PHPCS and SemGrep rules to minimize such occurrences, it's important to address these false positives in a systematic way.
 

--- a/docs/managed-tests/05-phpcompatibility.md
+++ b/docs/managed-tests/05-phpcompatibility.md
@@ -1,4 +1,4 @@
-# PHPCompatibility Tests
+# PHPCompatibility tests
 
 The PHPCompatibility test is a tool that helps developers assess the compatibility of their extension with different PHP versions. It checks the codebase of a plugin against a set of coding standards and best practices to ensure that it can run on a wide range of PHP versions, ensuring better compatibility and security. The following status will be returned from this test:
 - Success: No WordPress/PHP compatibility warning or errors.
@@ -12,7 +12,7 @@ If your phpcompatibility test is failing, please take the following steps:
 - Identify the causes of failure. The test will log any security issues that our scanner identifies
 - Fix the issue and re-run the test
 
-### Handling False Positives
+### Handling false positives
 
 We have chosen to utilize the `develop` branch of the PHPCompatibility project rather than version `9`. The reason for this choice is that the develop branch offers partial support for PHP 8+ syntax, which is essential for maintaining compatibility with modern PHP versions. However, it's important to note that this partial support may occasionally lead to false positives in the test results against codebases using 8+ syntax. 
 

--- a/docs/managed-tests/07-malware.md
+++ b/docs/managed-tests/07-malware.md
@@ -1,11 +1,11 @@
-# Malware Test
+# Malware tests
 
 Our malware scanner is designed to detect and identify potentially malicious or suspicious PHP code in web applications and files. It is primarily used for identifying PHP-based malware, backdoors, and other security threats that may have been injected into PHP files. The following status will be returned from this test:
 
 - Success: No malicious or suspicious code detected.
 - Falure: Something in the plugin under test has been flagged as potentially dangerous.
 
-## Types of Issues Flagged
+## Types of issues flagged
 - `NonPrintableChars`: Obfuscated or malicious PHP code that includes non-printable characters.
 PasswordProtection: It may indicate a weak or insecure password validation method.
 - `ObfuscatedPhp`: Functions like eval, preg_replace, and various evasion techniques used by obfuscation tools.

--- a/docs/managed-tests/_category_.json
+++ b/docs/managed-tests/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Managed Tests",
+    "label": "Managed tests",
     "position": 3,
     "link": {
         "type": "generated-index"

--- a/docs/support/authenticating.md
+++ b/docs/support/authenticating.md
@@ -2,11 +2,11 @@ import CLIAuthVideo from '@site/src/video/qit-cli-auth-flow.mp4';
 
 # Authenticating
 
-QIT is currently exclusive to Partner Developers that sells plugins in the Woo.com Marketplace.
+QIT is currently exclusive to Partner Developers that sell plugins in the WooCommerce.com Marketplace.
 
 ## Authenticating using QIT CLI
 
-- Login to Woo.com with your Partner Developer account
+- Login to WooCommerce.com with your Partner Developer account
 - [Download](https://github.com/woocommerce/qit-cli/releases/latest/) the latest version of QIT CLI and [Install it](/cli/01-installation.md)
 - Depending on how you've installed the QIT CLI, run `./vendor/bin/qit partner:add`
 - Follow the steps to generate a QIT Token
@@ -16,13 +16,13 @@ QIT is currently exclusive to Partner Developers that sells plugins in the Woo.c
     <source src={CLIAuthVideo} />
 </video>
 
-## Authenticating in the Woo.com Marketplace
+## Authenticating in the WooCommerce.com Marketplace
 
-We also provide a user interface to view and start test runs in the Woo.com Vendor Dashboard.
+We also provide a user interface to view and start test runs in the WooCommerce.com Vendor Dashboard.
 
 To access it:
 
-- Log in to Woo.com with your Partner account.
+- Log in to WooCommerce.com with your Partner account.
 - Click on `Vendor Dashboard` button to be taken to your vendor dashboard, which can be found on the My Account page once you've logged in:
 
 ![go-to-dashboard](../woo-com/_media/go-to-dashboard.png)
@@ -31,11 +31,11 @@ To access it:
 
 ### Giving access to other developers to use QIT
 
-Sometimes you want to give access to other developers in your organization to run tests using the QIT, but you might not want to give them access to the Woo.com account that can manage the extension in the marketplace, as it gives developers access they don't need, such as managing your extensions in the marketplace, etc.
+Sometimes you want to give access to other developers in your organization to run tests using the QIT, but you might not want to give them access to the WooCommerce.com account that can manage the extension in the marketplace, as it gives developers access they don't need, such as managing your extensions in the marketplace, etc.
 
 Luckily, you can share with them the QIT Token, as they are restricted to only run and view test runs. They are special application passwords with limited access that can only run and view tests using QIT.
 
-### What's the Difference Between QIT Token and Application Password?
+### What's the difference between a QIT Token and an Application Password?
 
 Under the hood, a QIT Token is just an Application Password with a specific App ID.
 

--- a/docs/support/contact-us.md
+++ b/docs/support/contact-us.md
@@ -1,11 +1,11 @@
-# Contact Us  
+# Contact us
 
 We're here to help! If you have any questions, comments, or concerns, please don't hesitate to reach out to us. You can contact us by sending an email to [qit@woocommerce.com](mailto:qit@woocommerce.com).
 
-## Report Issues  
+## Report issues
 
 If you encounter any issues with our QIT CLI tool, please let us know by opening an issue on our GitHub repository. You can access the repository here: https://github.com/woocommerce/qit-cli/issues
 
-## Provide Feedback  
+## Provide feedback
 
 We value your feedback and suggestions. Please take a moment to let us know how we're doing by filling out [this feedback form](#). Your input will help us continue to improve.

--- a/docs/support/test-options.md
+++ b/docs/support/test-options.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Test Options
+# Test options
 
 The table below shows what options are available for each test type. For example, for Activation tests you can supply a WordPress version but for the security tests it isn't supported.
 

--- a/docs/woo-com/_category_.json
+++ b/docs/woo-com/_category_.json
@@ -1,5 +1,5 @@
 {
-    "label": "Woo.com Dashboard",
+    "label": "WooCommerce.com dashboard",
     "position": 5,
     "link": {
         "type": "generated-index"

--- a/docs/woo-com/getting-started.md
+++ b/docs/woo-com/getting-started.md
@@ -1,8 +1,8 @@
-# QIT in Woo.com
+# QIT in WooCommerce.com
 
-The QIT Dashboard is a tool available to extension developers in the Woo administrative interface. This tool allows developers to run a variety of tests with their extension installed in a test environment, configured with the latest version of WordPress and either the release candidate or latest version of WooCommerce. If you have multiple extensions, you can select the extension you’d like to run the tests against.
+The QIT Dashboard is a tool available to extension developers in the WooCommerce administrative interface. This tool allows developers to run a variety of tests with their extension installed in a test environment, configured with the latest version of WordPress and either the release candidate or latest version of WooCommerce. If you have multiple extensions, you can select the extension you’d like to run the tests against.
 
-To get started, you'll need to log in to your account on Woo.com. Once you log in to your account, click on "Vendor Dashboard" to go to your dashboard:
+To get started, you'll need to log in to your account on WooCommerce.com. Once you log in to your account, click on "Vendor Dashboard" to go to your dashboard:
 
 ![go-to-dashboard](_media/go-to-dashboard.png)
 

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -4,7 +4,7 @@ import styles from './styles.module.css';
 
 const FeatureList = [
     {
-        title: 'Managed Tests',
+        title: 'Managed tests',
         Svg: require('@site/static/img/managed_tests.svg').default,
         description: (
             <>
@@ -13,7 +13,7 @@ const FeatureList = [
         ),
     },
     {
-        title: 'Custom E2E Tests',
+        title: 'Custom E2E tests',
         Svg: require('@site/static/img/integrated_e2e.svg').default,
         description: (
             <>
@@ -22,7 +22,7 @@ const FeatureList = [
         ),
     },
     {
-        title: 'Local Test Environment',
+        title: 'Local test environment',
         Svg: require('@site/static/img/local_environment.svg').default,
         description: (
             <>
@@ -32,7 +32,7 @@ const FeatureList = [
     },
 ];
 
-function Feature({Svg, title, description}) {
+function Feature({ Svg, title, description }) {
     return (
         <div className={clsx('col col--4')}>
             <div className="text--center">

--- a/src/components/TestTypes.js
+++ b/src/components/TestTypes.js
@@ -6,30 +6,30 @@ export default function TestTypes({ includeCode = false }) {
     return (
         <ul>
             <li>
-                Managed Tests
+                Managed tests
                 <ul>
-                    <li><a href="/docs/managed-tests/woo-e2e">Woo E2E Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:woo-e2e</code></li>
-                    <li><a href="/docs/managed-tests/woo-api">Woo API Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:woo-api</code></li>
-                    <li><a href="/docs/managed-tests/activation">Activation Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:activation</code></li>
-                    <li><a href="/docs/managed-tests/security">Security Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:security</code></li>
-                    <li><a href="/docs/managed-tests/phpstan">PHPStan Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:phpstan</code></li>
-                    <li><a href="/docs/managed-tests/phpcompatibility">PHPCompatibility Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:phpcompatibility</code></li>
-                    <li><a href="/docs/managed-tests/malware">Malware Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:malware</code></li>
-                    <li>Performance Tests <i>(Coming soon)</i></li>
+                    <li><a href="/docs/managed-tests/woo-e2e">Woo E2E tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:woo-e2e</code></li>
+                    <li><a href="/docs/managed-tests/woo-api">Woo API tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:woo-api</code></li>
+                    <li><a href="/docs/managed-tests/activation">Activation tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:activation</code></li>
+                    <li><a href="/docs/managed-tests/security">Security tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:security</code></li>
+                    <li><a href="/docs/managed-tests/phpstan">PHPStan tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:phpstan</code></li>
+                    <li><a href="/docs/managed-tests/phpcompatibility">PHPCompatibility tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:phpcompatibility</code></li>
+                    <li><a href="/docs/managed-tests/malware">Malware tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:malware</code></li>
+                    <li>Performance tests <i>(Coming soon)</i></li>
                 </ul>
             </li>
             <li>
-                Custom Tests
+                Custom tests
                 <ul>
-                    <li><a href="/docs/custom-tests/introduction">Custom E2E Tests</a> <code
-                        style={{display: includeCode ? 'inline-block' : 'none'}}>run:e2e</code></li>
+                    <li><a href="/docs/custom-tests/introduction">Custom E2E tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:e2e</code></li>
                 </ul>
             </li>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,15 +9,15 @@ import styles from './index.module.css';
 import QITImageURL from '@site/static/img/qit-left.webp';
 
 function HomepageHeader() {
-    const {siteConfig} = useDocusaurusContext();
+    const { siteConfig } = useDocusaurusContext();
     return (
         <header className={clsx('hero hero--primary', styles.heroBanner)}>
             <div className="container">
-                <img src={QITImageURL} width={200}/>
+                <img src={QITImageURL} width={200} />
                 <Heading as="h1" className="hero__title">
                     <span>Quality Insights Toolkit, or just QIT.</span>
                 </Heading>
-                <p className="hero__subtitle">A Testing Platform for WordPress Plugins and Themes.</p>
+                <p className="hero__subtitle">A testing platform for WordPress plugins and themes.</p>
                 <div className={styles.buttons}>
                     <Link
                         className="button button--secondary button--lg"
@@ -31,7 +31,7 @@ function HomepageHeader() {
 }
 
 export default function Home() {
-    const {siteConfig} = useDocusaurusContext();
+    const { siteConfig } = useDocusaurusContext();
     return (
         <Layout
             title=""


### PR DESCRIPTION
As I was working on the validation test docs I noticed some inconsistencies; this PR addresses most or all of them, but is also rather opinionated. We may want some, all, or none of it!

The main things:
- Consistently sentence case headings (which also affects the sidebar); i.e. `Directory Structure` -> `Directory structure`). We had both styles before inconsistently; this tries to unify them.
- Not capitalizing things that are almost names; so `GitHub` and `GitHub Workflows` stay, but `Managed Tests` -> `Managed tests` and `Local Test Environment` -> `Local test environment`. This is the maybe more controversial set of changes.
- Woo.com -> WooCommerce.com, and mostly Woo -> WooCommerce, to align with the move back and our branding (I think).

Let's discuss!