### PR TITLE
Update docs for Activation test

### DIFF
--- a/docs/managed-tests/03-activation.md
+++ b/docs/managed-tests/03-activation.md
@@ -26,6 +26,39 @@ The Activation test type performs basic operations on a test site with your plug
 
 You can tweak several parameters in the Activation Test, such as Woo, WP, and PHP versions, etc. You can see all options by running `qit run:activation --help` in the QIT CLI.
 
+### Skipping Visited Pages
+
+If you want the Activation test to skip specific pages added by your plugin, you can add a `qit.json` file to your plugin's root directory (the same directory as your plugin entrypoint) with the following content:
+
+```json
+{
+  "activation": {
+    "skipVisitPages": [
+      "wp-admin/admin.php?page=skip-visiting-this"
+    ]
+  }
+}
+```
+  - **Automatic Page Discovery:** By default, the test suite will visit all pages accessible from the WordPress admin sidebar menu that are added by your plugin.
+  - **skipVisitPages Array:** The `skipVisitPages` array in the `qit.json` file specifies the URLs of pages you want to exclude from being visited during the tests.
+  - **Substring Matching:** The skipping mechanism works based on substring matching. This means that if any part of a page's URL contains a string listed in the skipVisitPages array, that page will be skipped during the tests.
+    
+    For example, if you include "wp-admin/admin.php?page=skip-visiting-this" in the `skipVisitPages` array, any admin page URL containing that substring will not be visited during the E2E tests.
+
+### Visiting a specific page
+
+Similarly, you can define specific pages to be visited, that might not be visible from the sidebar menu. It only accepts relative URLs.
+
+```json
+{
+  "activation": {
+    "visitPages": [
+      "wp-admin/admin.php?page=visit-this"
+    ]
+  }
+}
+```
+
 ### How to run the test
 
 You can run the activation test with the following command:

--- a/docs/managed-tests/03-activation.md
+++ b/docs/managed-tests/03-activation.md
@@ -47,14 +47,16 @@ If you want the Activation test to skip specific pages added by your plugin, you
 
 ### Visiting a specific page
 
-Similarly, you can define specific pages to be visited, that might not be visible from the sidebar menu. It only accepts relative URLs.
+You can also define specific pages to be visited, that might not be visible from the sidebar menu.
+
+It **uses a slightly different syntax**, as it takes a page title and a URL. It only accepts relative URLs.
 
 ```json
 {
   "activation": {
-    "visitPages": [
-      "wp-admin/admin.php?page=visit-this"
-    ]
+    "visitPages": {
+      "Visit This": "wp-admin/admin.php?page=do-visit-this"
+    }
   }
 }
 ```

--- a/docs/managed-tests/03-activation.md
+++ b/docs/managed-tests/03-activation.md
@@ -1,10 +1,38 @@
 # Activation tests
 
-The Activation test type activates your extension against a freshly created shop and captures any PHP errors or warnings that may occur on activation. This test sets up a WooCommerce store using the provided WordPress and WooCommerce versions. The following statuses will be returned from this test:
+The Activation test type performs basic operations on a test site with your plugin activated.
 
-- Success: No PHP notices, warnings, or errors were triggered.
-- Warning: A non-fatal PHP error was triggered.
-- Failure: A fatal PHP error was triggered.
+### The operations are:
+
+- Log-in as admin
+- Activate any dependencies that your plugin has (e.g. WooCommerce)
+- Activate your plugin
+- Visit and take screenshots of any pages added by your plugin to the wp-admin menu
+- Enable Cash on Delivery payment method
+- Enable Local Pickup shipping method
+- Create a product
+- Create an order
+- Add a product to cart
+- Place an order as a guest
+- Deactivate your plugin
+
+### The status of the test is determined by the following:
+
+- Success: All flows were completed, and no PHP notices, warnings, or errors were triggered.
+- Warning: All flows were completed, but a non-fatal PHP error was triggered.
+- Failed: One of the flows failed, or a fatal PHP error was triggered.
+
+### Configurable Options:
+
+You can tweak several parameters in the Activation Test, such as Woo, WP, and PHP versions, etc. You can see all options by running `qit run:activation --help` in the QIT CLI.
+
+### How to run the test
+
+You can run the activation test with the following command:
+
+```qitbash
+qit run:activation <your-plugin>
+```
 
 ## What to do if it fails
 


### PR DESCRIPTION
Basic docs for the refactored Activation Test just so that it's not so outdated.

![image](https://github.com/user-attachments/assets/653260ad-bf4c-4cd8-98d2-7fe14f78651c)