### PR TITLE
Update validation docs for new headers and include more explanation

### DIFF
--- a/docs/managed-tests/08-validation.md
+++ b/docs/managed-tests/08-validation.md
@@ -1,12 +1,21 @@
-# Validation Tests
+# Validation tests
 
 Our validation test is designed to inform you of any issues with plugin and theme metadata. Right now it is purely informative, but in the future it may block submissions or updates.
 
-## Types of Issues Flagged
-The presence and value of certain headers will be checked:
+## Types of issues flagged
+The presence or absence of certain headers will be checked; both the main plugin or theme file as well as the `readme.txt` will be checked, with priority given to the main file.
 
-- `Requires PHP` - warning if not present in main plugin or theme file.
-- More coming soon!
+The following headers should be present, and will result in a warning if not:
+
+- `Requires PHP` - so that users know if your extension requires a specific version of PHP.
+- `Requires at least` - so that users know if your extension requires a specific version of WordPress.
+- `Tested up to` - so users can be sure that your extension works correctly with recent WordPress versions.
+- `WC requires at least` - so that users know if your extension requires a specific version of WooCommerce.
+- `WC tested up to` - so users can be sure that your extension works correctly with recent WooCommerce versions.
+
+The following headers should not be present when submitted, and will result in a warning if they are:
+
+- `Woo` - as discussed [here](https://woocommerce.com/document/create-a-plugin/#section-14), this header will be added automatically during the deployment process; in order to avoid issues with incorrect headers or when distributing the same plugin outside the Marketplace, we recommend not including it manually.
 
 ## What to do if it fails
 

--- a/src/components/TestTypes.js
+++ b/src/components/TestTypes.js
@@ -22,7 +22,7 @@ export default function TestTypes({ includeCode = false }) {
                         style={{ display: includeCode ? 'inline-block' : 'none' }}>run:phpcompatibility</code></li>
                     <li><a href="/docs/managed-tests/malware">Malware tests</a> <code
                         style={{ display: includeCode ? 'inline-block' : 'none' }}>run:malware</code></li>
-                    <li><a href="/docs/managed-tests/validation">Validation Tests</a> <code
+                    <li><a href="/docs/managed-tests/validation">Validation tests</a> <code
                         style={{ display: includeCode ? 'inline-block' : 'none' }}>run:validation</code></li>
                     <li>Performance tests <i>(Coming soon)</i></li>
                 </ul>


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce.com/issues/21731

This:

- Adds the new headers we're now checking, and breaks them into groups based on what should and should not be present.
- Gives more explanation on why the vendor cares about each item, and our reasoning on the `Woo` header.
- Fixes the sentence casing to be consistent with all the other changes I made recently.

Testing:

Proofread it, make sure it makes sense and has no typos.