### PR TITLE
Add documentation for plugin-check tests

### DIFF
--- a/docs/managed-tests/09-plugin-check.md
+++ b/docs/managed-tests/09-plugin-check.md
@@ -12,4 +12,4 @@ If your plugin check test is failing, please review the following steps:
 - Open the test report.
 - Identify the causes of the failure and remedy it.
 - Please note that QIT does not control the underlying rules or engine for this test; if you believe you have found an issue with the check itself, you can [open an issue](https://github.com/WordPress/plugin-check/issues) for the `plugin-check` tool.
-- If instead you believe you've run across a bug in the QIT infrastrucutre around the test, please email us at qit@woocommerce.com so we can review and make the necessary adjustments.
+- If instead you believe you've run across a bug in the QIT infrastructure around the test, please email us at qit@woocommerce.com so we can review and make the necessary adjustments.

--- a/docs/managed-tests/09-plugin-check.md
+++ b/docs/managed-tests/09-plugin-check.md
@@ -1,0 +1,15 @@
+# wordpress.org Plugin Check tests
+
+The [wordpress.org automated plugin check](https://wordpress.org/plugins/plugin-check) tool can be run in QIT as a dedicated test type. Currently this test will **not** be run automatically on any submissions, though this may change in the future. However, if you've already integrated QIT into your development pipeline and are also deploying to wordpress.org, you can now run this additional test using the same setup.
+
+## Types of issues flagged
+
+Only checks from the `plugin_repo` category will be run; these should flag obvious violations of the [wordpress.org plugin review guidelines](https://make.wordpress.org/plugins/handbook/performing-reviews/review-checklist/). In the future it may be possible to run other categories or specific checks on demand, depending on developer needs and internal priorities.
+
+## What to do if it fails
+
+If your plugin check test is failing, please review the following steps:
+- Open the test report.
+- Identify the causes of the failure and remedy it.
+- Please note that QIT does not control the underlying rules or engine for this test; if you believe you have found an issue with the check itself, you can [open an issue](https://github.com/WordPress/plugin-check/issues) for the `plugin-check` tool.
+- If instead you believe you've run across a bug in the QIT infrastrucutre around the test, please email us at qit@woocommerce.com so we can review and make the necessary adjustments.

--- a/docs/support/test-options.md
+++ b/docs/support/test-options.md
@@ -6,14 +6,14 @@ sidebar_position: 1
 
 The table below shows what options are available for each test type. For example, for Activation tests you can supply a WordPress version but for the security tests it isn't supported.
 
-|                              | Activation | Woo E2E | Woo API | Security | PHPStan | Validation |
-| ---------------------------- | ---------- |---------|---------| -------- | ------- | ---------- |
-| WordPress Versions           | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
-| WooCommerce Versions         | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
-| WooCommerce Features         | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
-| PHP Version                  | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
-| Additional Extensions        | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
-| Additional WordPress Plugins | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        |
+|                              | Activation | Woo E2E | Woo API | Security | PHPStan | Validation | Plugin Check |
+| ---------------------------- | ---------- |---------|---------| -------- | ------- | ---------- | ------------ |
+| WordPress Versions           | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        | ❌           |
+| WooCommerce Versions         | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        | ❌           |
+| WooCommerce Features         | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        | ❌           |
+| PHP Version                  | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        | ❌           |
+| Additional Extensions        | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        | ❌           |
+| Additional WordPress Plugins | ✅         | ✅       | ✅       | ❌       | ❌      | ❌        | ❌           |
 
 ## WordPress and WooCommerce versions
 

--- a/src/components/TestTypes.js
+++ b/src/components/TestTypes.js
@@ -24,6 +24,8 @@ export default function TestTypes({ includeCode = false }) {
                         style={{ display: includeCode ? 'inline-block' : 'none' }}>run:malware</code></li>
                     <li><a href="/docs/managed-tests/validation">Validation tests</a> <code
                         style={{ display: includeCode ? 'inline-block' : 'none' }}>run:validation</code></li>
+                    <li><a href="/docs/managed-tests/plugin-check">wordpress.org Plugin Check tests</a> <code
+                        style={{ display: includeCode ? 'inline-block' : 'none' }}>run:plugin-check</code></li>
                     <li>Performance tests <i>(Coming soon)</i></li>
                 </ul>
             </li>


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce.com/issues/22010

This PR just adds some basic documentation for the plugin-check test type. It tries to direct people to the wordpress.org/GH resources wherever possible, notably for issues with the rules/detection.