### PR TITLE
Docs for auth required for downloading premium extensions

### DIFF
--- a/docs/core-concepts/test-types-overview.md
+++ b/docs/core-concepts/test-types-overview.md
@@ -51,3 +51,19 @@ By combining both types of tests, you get a thorough quality assurance process:
 - **Before release:** Managed tests confirm baseline standards are met.
 - **During development:** Custom tests verify new features and custom behaviors.
 - **Ongoing maintenance:** Regularly running both test suites helps ensure continuous stability and compatibility as WordPress, WooCommerce, and your extension evolve.
+
+## Working with Additional Extensions
+
+When testing your main extension (SUT), you may also want to include other plugins—e.g., dependencies, compatibility targets, or popular add-ons. The process differs slightly between Managed Tests and Custom Tests:
+
+- **Managed Tests**
+    - QIT automatically downloads your extension from WooCommerce.com if you own it.
+    - Additional paid extensions must also be owned by your account, or they won’t be fetched.
+    - Some WooCommerce.com extensions that are also listed for free on WordPress.org may be downloaded automatically, even if you don’t own them.
+    - **Local ZIP sources** are allowed **only for the SUT** (if you maintain it).
+    - No custom test tags or additional custom code can be included.
+
+- **Custom Tests**
+    - You can add any extension to your test environment via Marketplace (if owned), WordPress.org (if free), or a **local ZIP** (if you don’t own it, or it’s hosted elsewhere).
+    - You can also create and upload custom test tags and specialized test flows.
+    - This flexibility is ideal for compatibility checks with plugins you don’t maintain or custom dev builds.

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -1,71 +1,106 @@
-# Downloading Extensions and Tests
+# Downloading extensions and tests
 
-QIT automatically downloads the extension you are testing (SUT), as well as any additional plugins, dependencies, and their respective custom test tags, if needed.
+QIT (Quality Insights Toolkit) automatically downloads the extension you are testing (the **System Under Test, or SUT**) and any related plugins, dependencies, and test tags. By default, it fetches the latest stable versions from WooCommerce.com for premium extensions and WordPress.org for free plugins.
 
-By default, it fetches stable versions from WooCommerce.com (for premium extensions) or WordPress.org (for free plugins).
+## Downloading premium extensions
 
-## Downloading Premium Extensions
+Premium extensions require authentication. The account used during `qit connect` must own and maintain the premium extension you want to test. If you do not own it, you must provide a local source (for example, a ZIP file containing the extension).
 
-Access to premium extensions on WooCommerce.com is tied to the WooCommerce.com account associated with the QIT Token you obtained during the `qit connect` process. If your account owns and can manage the extension, QIT can download it remotely. Otherwise, you must provide a local source.
+For more details, see [Authenticating with QIT](../installation-setup/authenticating.md).
 
-For detailed steps on authenticating with QIT, see Authenticating with QIT.
+## Downloading free extensions
 
-## Understanding Permissions and Ownership
+Free extensions are sourced directly from WordPress.org without requiring authentication or ownership. You can still provide a local source if you want to test a modified version rather than the publicly available one.
 
-- **Premium Extensions (WooCommerce.com):**  
-  You must own the extension in your WooCommerce.com account to download it remotely. If you do not have access, QIT will fail to fetch it. In that case, providing a local source (e.g., a development build) ensures the test run can continue.
+## SUT must exist in the marketplace
 
-- **Free Extensions (WordPress.org):**  
-  No special permissions are required. QIT downloads them automatically. You can still provide a local source if you want to test a modified or private version.
+Your SUT must be recognized in the WooCommerce.com marketplace and associated with your account. Although you can override the downloaded code with a local source (such as a development build), the SUT itself must be listed in the marketplace for the test results to be recorded.
 
-- **Not Listed on WooCommerce.com:**  
-  If the extension isn’t available in the marketplace, you must provide a local source.
+## Additional plugins and dependencies
 
-## The System Under Test (SUT)
+- **Premium (WooCommerce.com):** You must own the extension or provide a local source.
+- **Free (WordPress.org):** No authentication is required.
+- **Not listed in either marketplace:** A local source is required.
 
-- **Premium SUT:** You must own it on WooCommerce.com or provide a local source.
-- **Free SUT:** Automatically fetched; local source optional for testing custom builds.
-- **SUT Not Listed:** Must provide a local source directly.
+## Custom tests (test tags)
 
-## Additional Plugins and Dependencies
+- **Remote tests:** You must own the extension associated with the test or provide a local source.
+- **Local tests:** If remote tests are not available, you can use a local directory or ZIP file.
+- **Conflicts:** If a test tag exists both remotely and locally, QIT will warn you and then default to the remote version.
 
-- **Free (WPORG):** Downloaded automatically.
-- **Premium (WCCOM):** Requires ownership; otherwise provide a local source.
-- **Not Listed:** Provide a local source.
+## Providing local sources
 
-This unified approach ensures that if you lack remote access, you can always fall back on a local source.
-
-## Custom Tests (Test Tags)
-
-- **Remote Tests:** QIT fetches them if you have the required access.
-- **Local Tests:** If remote tags aren’t accessible or don’t exist, provide a local directory or zip.
-- **Conflicts:** If the same tag exists both remotely and locally, QIT warns you and uses the remote version by default.
-
-## Providing Local Sources
-
-To supply a local source, add a `source` attribute in `qit.yml`:
-
-```yaml
-plugins:
-  my-premium-sut:
-    source: ./my-premium-sut.zip
-```
-
-For tests:
+In `qit.yml`:
 
 ```yaml
 plugins:
   my-plugin:
+    source: ./my-plugin.zip
     test_tags:
       - ./local-tests/my-plugin-tests
 ```
 
-## Error Handling
+## Installing from other sources
 
-- **No Ownership:** QIT reports that it can’t fetch the extension. Provide proper credentials or a local source.
-- **Not Found Remotely:** Check the slug or add a local source.
-- **Local vs Remote (Tests):** QIT warns on conflict; remote is used unless you adjust your setup.
+To fetch extensions from unsupported locations (such as private Git repositories), implement **custom handlers**. For details, see [Advanced Config Handlers](./../advanced-usage/advanced-config-handlers.md).
 
-## Installing Plugins and Themes from Other Sources
+## Example scenario - Step by Step
 
-While QIT works seamlessly with WordPress.org and WooCommerce.com listings—plus local sources—you may need to fetch extensions from other locations like private GitHub repositories or premium marketplaces not directly supported by QIT. In these cases, you can implement **custom handlers** that define how QIT should retrieve and prepare these plugins or themes. For more details and examples, refer to the [Advanced Config Handlers documentation](./../advanced-usage/advanced-config-handlers.md).
+Below is an example scenario where we run a Custom E2E test, which explains how QIT applies its rules for downloading.
+
+Let's suppose you are the developer of `my-extension` - you want to include `automatewoo-birthdays` in your test, but you don't own it.
+
+So at first, you run this command:
+
+```qitbash
+qit run:e2e my-extension -p automatewoo-birthdays
+```
+
+This will fail because you don't have access to `automatewoo-birthdays` and `automatewoo` (which is a dependency).
+
+We will see now what QIT does step-by-step, and how you can get around this by providing the zips of these premium plugins locally.
+
+### What happens step-by-step:
+
+1`my-extension` (SUT):
+  - QIT checks WooCommerce.com to see if you own `my-extension`.
+  - Since you do, it downloads the latest stable release of `my-extension` from WooCommerce.com and the `default` custom test tag.
+  - No local source is required here, but you could specify one if you wanted to test a development build.
+
+2. `automatewoo-birthdays` (additional plugin):
+  - This is a paid extension, and you are not it's maintainer.
+  - QIT cannot download it from WooCommerce.com, so it looks for a local source in `qit.yml` or in the CLI parameters.
+  - You must provide something like `source: ./automatewoo-birthdays.zip`. If you don’t, QIT can’t proceed with this plugin.
+
+3. `automatewoo` (dependency):
+  - "automatewoo-birthdays" depends on "automatewoo," another premium extension you don’t maintain.
+  - QIT again checks if you own "automatewoo" on WooCommerce.com. Since in this scenario you do not, it looks for a local source.
+  - You must supply `source: ./automatewoo.zip` in `qit.yml`.
+
+5. `woocommerce` (dependency):
+  - Let's suppose "automatewoo" depends on "woocommerce".
+  - "woocommerce" is free and available on WordPress.org.
+  - QIT downloads it automatically without needing authentication or a local source.
+
+**Example `qit.yml` configuration:**
+
+```yaml
+plugins:
+  my-extension:
+    # Owned premium extension, no source needed unless overriding
+    # source: ./my-extension.zip (optional if you want to test a development build)
+
+  automatewoo-birthdays:
+    # Premium, not owned → must provide local source
+    source: ./automatewoo-birthdays.zip
+
+  automatewoo:
+    # Premium, not owned → must provide local source
+    source: ./automatewoo.zip
+
+  # woocommerce:
+  #   Free, automatically fetched from WordPress.org if no source provided.
+  #   Listing it here is optional.
+```
+
+This scenario shows how starting from the CLI command, QIT applies a consistent set of rules based on ownership, marketplace availability, and local overrides to set up the testing environment.

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -41,8 +41,6 @@ plugins:
 
 To fetch extensions from unsupported locations (such as private Git repositories), implement **custom handlers**. For details, see [Advanced Config Handlers](./../advanced-usage/advanced-config-handlers.md).
 
-Below is a refined version that incorporates all your changes and additions:
-
 ## Example scenario – step by step
 
 Below is an example scenario where we run a custom E2E test to demonstrate how QIT applies its downloading rules.
@@ -110,8 +108,6 @@ qit run:e2e my-extension -p automatewoo-birthdays
 ```
 
 now succeeds. QIT sets up the environment by fetching what you own and using local sources for what you don’t.
-
-This scenario demonstrates how QIT consistently applies rules based on ownership, marketplace availability, and local overrides.
 
 ---
 

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -1,6 +1,6 @@
 # Downloading extensions and tests
 
-QIT automatically downloads the extension you are testing **(SUT)** and any additional plugins, dependencies, and test tags. By default, QITc fetches the latest stable versions from WooCommerce.com for paid extensions and WordPress.org for free plugins.
+QIT automatically downloads the extension you are testing **(SUT)** and any additional plugins, dependencies, and test tags. By default, QIT fetches the latest stable versions from WooCommerce.com for paid extensions and WordPress.org for free plugins.
 
 ## The extension under test
 

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -1,29 +1,29 @@
 # Downloading extensions and tests
 
-QIT automatically downloads the extension you are testing **(SUT)** and any additional plugins requested, dependencies, and test tags. By default, it fetches the latest stable versions from WooCommerce.com for paid extensions and WordPress.org for free plugins.
+QIT automatically downloads the extension you are testing **(SUT)** and any additional plugins, dependencies, and test tags. By default, QITc fetches the latest stable versions from WooCommerce.com for paid extensions and WordPress.org for free plugins.
 
 ## The extension under test
 
-The main extension you're testing (SUT) must be a product in the WooCommerce.com marketplace and associated with your account. The account used during `qit connect` **must be the maintainer of this extension**. It can be a product submission or a published product.
+The main extension you are testing must be a product in the WooCommerce.com marketplace and associated with your account. The account used during `qit connect` **must be the maintainer of this extension**. This can be a product submission or a published product.
 
 For more details, see [Authenticating with QIT](../installation-setup/authenticating.md).
 
 ## Downloading paid extensions
 
-Paid extensions require authentication. Similar to the sut, you **must be the maintainer of the paid extension** you want to include in your test. If you do not own it, you must provide a local source (for example, a ZIP file containing the extension).
+Paid extensions require authentication. Similar to the SUT, you **must be the maintainer of the paid extension** you want to include in your test. If you do not own it, you must provide a local source (for example, a ZIP file containing the extension).
 
-You can find examples of providing local sources below.
+Below you’ll find examples of providing local sources.
 
 ## Downloading free extensions
 
-Free extensions are sourced directly from WordPress.org without requiring authentication or ownership. You can still provide a local source if you want to test a modified version rather than the publicly available one.
+Free extensions are sourced directly from WordPress.org without requiring authentication or ownership. You can still provide a local source if you want to test a modified or development version.
 
-## Additional plugins, dependencies and test tags
+## Additional plugins, dependencies, and test tags
 
-- **Paid (WooCommerce.com):** You must be the maintainer of the extension or provide a local source.
+- **Paid (WooCommerce.com):** You must be the maintainer or provide a local source.
 - **Free (WordPress.org):** No authentication is required.
 - **Not listed in either marketplace:** A local source is required.
-- **Custom test tags**: You must own the extension associated with the test you want to use, or provide a local source.
+- **Custom test tags**: You must own the associated extension or provide a local source.
 
 ## Providing local sources
 
@@ -41,42 +41,45 @@ plugins:
 
 To fetch extensions from unsupported locations (such as private Git repositories), implement **custom handlers**. For details, see [Advanced Config Handlers](./../advanced-usage/advanced-config-handlers.md).
 
-## Example scenario - Step by Step
+Below is a refined version that incorporates all your changes and additions:
 
-Below is an example scenario where we run a Custom E2E test, which explains how QIT applies its rules for downloading.
+## Example scenario – step by step
 
-Let's suppose you are the developer of `my-extension` - you want to include `automatewoo-birthdays` in your test, but you don't own it.
+Below is an example scenario where we run a custom E2E test to demonstrate how QIT applies its downloading rules.
 
-So at first, you run this command:
+**Scenario:** You are the developer of `my-extension` (your SUT), and you want to include `automatewoo-birthdays` in your test. However, you don’t maintain `automatewoo-birthdays` or its dependency `automatewoo`, both of which are paid extensions.
 
-```qitbash
+At first, you run this command:
+
+```bash
 qit run:e2e my-extension -p automatewoo-birthdays
 ```
 
-This will fail because you don't have access to `automatewoo-birthdays` and `automatewoo` (which is a dependency).
+This will fail because you don’t have access to `automatewoo-birthdays` or `automatewoo`.
 
-We will see now what QIT does step-by-step, and how you can get around this by providing the zips of these paid plugins locally.
+Let’s see how QIT processes each step and how you can resolve this by providing local ZIP files for the paid plugins you don’t own.
 
 ### What happens step-by-step:
 
-- `my-extension` **(SUT)**:
-  - QIT checks WooCommerce.com to see if you own `my-extension`.
-  - Since you do, it downloads the latest stable release of `my-extension` from WooCommerce.com and the `default` custom test tag.
-  - No local source is required. However, if you wanted to test a development build, you could specify a local ZIP file.
+- **`my-extension` (SUT)**:
+  - QIT checks WooCommerce.com to confirm that you maintain `my-extension`.
+  - Since you do, it downloads the latest stable release of `my-extension` and the `default` custom test tag.
+  - No local source is required. If you wanted to test a development build, you could provide a local ZIP instead.
 
-- `automatewoo-birthdays` **(additional plugin)**:
+- **`automatewoo-birthdays` (additional plugin)**:
   - This is a paid extension that you do not maintain.
-  - QIT cannot download it from WooCommerce.com, so it looks for a local source in `qit.yml` (or via CLI parameters).
-  - If none is provided, QIT can’t proceed.
+  - QIT cannot download it from WooCommerce.com, so it checks `qit.yml` for a local source.
+  - If no local source is provided, QIT cannot proceed.
 
-- `automatewoo` **(dependency)**:
+- **`automatewoo` (dependency)**:
   - `automatewoo-birthdays` depends on `automatewoo`, another paid extension you don’t maintain.
-  - QIT checks if you own `automatewoo` on WooCommerce.com. Since you don’t, it expects a local source.
-  - Similarly as above, you must define the source yourself.
+  - QIT checks WooCommerce.com for `automatewoo`. Since you don’t own it, QIT expects a local source.
+  - You must provide something like `./automatewoo.zip`.
 
-- `woocommerce` **(dependency)**:
+- **`woocommerce` (dependency)**:
   - Suppose `automatewoo` depends on `woocommerce`.
-  - `woocommerce` is free and available on WordPress.org, so QIT automatically fetches it. No local source or authentication is needed.
+  - `woocommerce` is free and available on WordPress.org.
+  - QIT automatically fetches it without needing a local source or authentication.
 
 **Example `qit.yml` configuration:**
 
@@ -88,24 +91,34 @@ plugins:
     # source: ./my-extension.zip
 
   automatewoo-birthdays:
-    # Paid, not the maintainer → must provide a local source
+    # Paid, not maintained by you → must provide a local source
     source: ./automatewoo-birthdays.zip
 
   automatewoo:
-    # Paid, not the maintainer → must provide a local source
+    # Paid, not maintained by you → must provide a local source
     source: ./automatewoo.zip
 
   # woocommerce:
-  #   Free, automatically fetched from WordPress.org if no source provided.
+  #   Free, automatically fetched from WordPress.org if no source is provided.
   #   Listing it here is optional.
 ```
 
-This scenario demonstrates how QIT applies a consistent set of rules based on ownership, marketplace availability, and local overrides to create the necessary test environment.
+With this configuration, running:
+
+```bash
+qit run:e2e my-extension -p automatewoo-birthdays
+```
+
+now succeeds. QIT sets up the environment by fetching what you own and using local sources for what you don’t.
+
+This scenario demonstrates how QIT consistently applies rules based on ownership, marketplace availability, and local overrides.
+
+---
 
 ## Future improvements
 
-We understand that managing access to paid extensions for certain vendors or accounts can be challenging, especially when aiming to leverage [Compatibility Testing](./compatibility-tests.md) between plugins.
+We recognize that managing paid extension access between vendors, collaborators, or specific developer accounts is a complex challenge, especially when aiming to conduct [compatibility tests](./compatibility-tests.md).
 
-To address this, we are planning to introduce **Access Control** in the future, allowing you to grant selected marketplace vendors or specific developer accounts access to your paid extensions and test tags.
+**Planned enhancements** include more flexible **Access Control**, enabling you to grant selected marketplace vendors or accounts the ability to access your paid extensions and test tags without everyone having to rely on local sources.
 
-We welcome your feedback on how you’d like to manage and share your paid extensions and tests. Please feel free to provide suggestions, use cases, or requirements.
+We encourage you to share your feedback and use cases, which will guide us in refining these upcoming features.

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -62,40 +62,40 @@ We will see now what QIT does step-by-step, and how you can get around this by p
 
 ### What happens step-by-step:
 
-1`my-extension` (SUT):
+- `my-extension` **(SUT)**:
   - QIT checks WooCommerce.com to see if you own `my-extension`.
   - Since you do, it downloads the latest stable release of `my-extension` from WooCommerce.com and the `default` custom test tag.
-  - No local source is required here, but you could specify one if you wanted to test a development build.
+  - No local source is required. However, if you wanted to test a development build, you could specify a local ZIP file.
 
-2. `automatewoo-birthdays` (additional plugin):
-  - This is a paid extension, and you are not it's maintainer.
-  - QIT cannot download it from WooCommerce.com, so it looks for a local source in `qit.yml` or in the CLI parameters.
-  - You must provide something like `source: ./automatewoo-birthdays.zip`. If you don’t, QIT can’t proceed with this plugin.
+- `automatewoo-birthdays` **(additional plugin)**:
+  - This is a paid extension that you do not maintain.
+  - QIT cannot download it from WooCommerce.com, so it looks for a local source in `qit.yml` (or via CLI parameters).
+  - If none is provided, QIT can’t proceed.
 
-3. `automatewoo` (dependency):
-  - "automatewoo-birthdays" depends on "automatewoo," another premium extension you don’t maintain.
-  - QIT again checks if you own "automatewoo" on WooCommerce.com. Since in this scenario you do not, it looks for a local source.
-  - You must supply `source: ./automatewoo.zip` in `qit.yml`.
+- `automatewoo` **(dependency)**:
+  - `automatewoo-birthdays` depends on `automatewoo`, another premium extension you don’t maintain.
+  - QIT checks if you own `automatewoo` on WooCommerce.com. Since you don’t, it expects a local source.
+  - Similarly as above, you must define the source yourself.
 
-5. `woocommerce` (dependency):
-  - Let's suppose "automatewoo" depends on "woocommerce".
-  - "woocommerce" is free and available on WordPress.org.
-  - QIT downloads it automatically without needing authentication or a local source.
+- `woocommerce` **(dependency)**:
+  - Suppose `automatewoo` depends on `woocommerce`.
+  - `woocommerce` is free and available on WordPress.org, so QIT automatically fetches it. No local source or authentication is needed.
 
 **Example `qit.yml` configuration:**
 
 ```yaml
 plugins:
   my-extension:
-    # Owned premium extension, no source needed unless overriding
-    # source: ./my-extension.zip (optional if you want to test a development build)
+    # Premium extension that you maintain, automatically fetched from WooCommerce.com.
+    # Optionally override with a local zip if desired:
+    # source: ./my-extension.zip
 
   automatewoo-birthdays:
-    # Premium, not owned → must provide local source
+    # Premium, not the maintainer → must provide a local source
     source: ./automatewoo-birthdays.zip
 
   automatewoo:
-    # Premium, not owned → must provide local source
+    # Premium, not the maintainer → must provide a local source
     source: ./automatewoo.zip
 
   # woocommerce:
@@ -103,4 +103,12 @@ plugins:
   #   Listing it here is optional.
 ```
 
-This scenario shows how starting from the CLI command, QIT applies a consistent set of rules based on ownership, marketplace availability, and local overrides to set up the testing environment.
+This scenario demonstrates how QIT applies a consistent set of rules based on ownership, marketplace availability, and local overrides to create the necessary test environment.
+
+## Future improvements
+
+We understand that managing access to premium extensions for certain vendors or accounts can be challenging, especially when aiming to leverage [Compatibility Testing](./compatibility-tests.md) between plugins.
+
+To address this, we are planning to introduce **Access Control** in the future, allowing you to grant selected marketplace vendors or specific developer accounts access to your premium extensions and test tags.
+
+We welcome your feedback on how you’d like to manage and share your premium extensions and tests. Please feel free to provide suggestions, use cases, or requirements.

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -1,32 +1,29 @@
 # Downloading extensions and tests
 
-QIT (Quality Insights Toolkit) automatically downloads the extension you are testing (the **System Under Test, or SUT**) and any related plugins, dependencies, and test tags. By default, it fetches the latest stable versions from WooCommerce.com for premium extensions and WordPress.org for free plugins.
+QIT automatically downloads the extension you are testing **(SUT)** and any additional plugins requested, dependencies, and test tags. By default, it fetches the latest stable versions from WooCommerce.com for paid extensions and WordPress.org for free plugins.
 
-## Downloading premium extensions
+## The extension under test
 
-Premium extensions require authentication. The account used during `qit connect` must own and maintain the premium extension you want to test. If you do not own it, you must provide a local source (for example, a ZIP file containing the extension).
+The main extension you're testing (SUT) must be a product in the WooCommerce.com marketplace and associated with your account. The account used during `qit connect` **must be the maintainer of this extension**. It can be a product submission or a published product.
 
 For more details, see [Authenticating with QIT](../installation-setup/authenticating.md).
+
+## Downloading paid extensions
+
+Paid extensions require authentication. Similar to the sut, you **must be the maintainer of the paid extension** you want to include in your test. If you do not own it, you must provide a local source (for example, a ZIP file containing the extension).
+
+You can find examples of providing local sources below.
 
 ## Downloading free extensions
 
 Free extensions are sourced directly from WordPress.org without requiring authentication or ownership. You can still provide a local source if you want to test a modified version rather than the publicly available one.
 
-## SUT must exist in the marketplace
+## Additional plugins, dependencies and test tags
 
-Your SUT must be recognized in the WooCommerce.com marketplace and associated with your account. Although you can override the downloaded code with a local source (such as a development build), the SUT itself must be listed in the marketplace for the test results to be recorded.
-
-## Additional plugins and dependencies
-
-- **Premium (WooCommerce.com):** You must own the extension or provide a local source.
+- **Paid (WooCommerce.com):** You must be the maintainer of the extension or provide a local source.
 - **Free (WordPress.org):** No authentication is required.
 - **Not listed in either marketplace:** A local source is required.
-
-## Custom tests (test tags)
-
-- **Remote tests:** You must own the extension associated with the test or provide a local source.
-- **Local tests:** If remote tests are not available, you can use a local directory or ZIP file.
-- **Conflicts:** If a test tag exists both remotely and locally, QIT will warn you and then default to the remote version.
+- **Custom test tags**: You must own the extension associated with the test you want to use, or provide a local source.
 
 ## Providing local sources
 
@@ -58,7 +55,7 @@ qit run:e2e my-extension -p automatewoo-birthdays
 
 This will fail because you don't have access to `automatewoo-birthdays` and `automatewoo` (which is a dependency).
 
-We will see now what QIT does step-by-step, and how you can get around this by providing the zips of these premium plugins locally.
+We will see now what QIT does step-by-step, and how you can get around this by providing the zips of these paid plugins locally.
 
 ### What happens step-by-step:
 
@@ -73,7 +70,7 @@ We will see now what QIT does step-by-step, and how you can get around this by p
   - If none is provided, QIT can’t proceed.
 
 - `automatewoo` **(dependency)**:
-  - `automatewoo-birthdays` depends on `automatewoo`, another premium extension you don’t maintain.
+  - `automatewoo-birthdays` depends on `automatewoo`, another paid extension you don’t maintain.
   - QIT checks if you own `automatewoo` on WooCommerce.com. Since you don’t, it expects a local source.
   - Similarly as above, you must define the source yourself.
 
@@ -86,16 +83,16 @@ We will see now what QIT does step-by-step, and how you can get around this by p
 ```yaml
 plugins:
   my-extension:
-    # Premium extension that you maintain, automatically fetched from WooCommerce.com.
+    # Paid extension that you maintain, automatically fetched from WooCommerce.com.
     # Optionally override with a local zip if desired:
     # source: ./my-extension.zip
 
   automatewoo-birthdays:
-    # Premium, not the maintainer → must provide a local source
+    # Paid, not the maintainer → must provide a local source
     source: ./automatewoo-birthdays.zip
 
   automatewoo:
-    # Premium, not the maintainer → must provide a local source
+    # Paid, not the maintainer → must provide a local source
     source: ./automatewoo.zip
 
   # woocommerce:
@@ -107,8 +104,8 @@ This scenario demonstrates how QIT applies a consistent set of rules based on ow
 
 ## Future improvements
 
-We understand that managing access to premium extensions for certain vendors or accounts can be challenging, especially when aiming to leverage [Compatibility Testing](./compatibility-tests.md) between plugins.
+We understand that managing access to paid extensions for certain vendors or accounts can be challenging, especially when aiming to leverage [Compatibility Testing](./compatibility-tests.md) between plugins.
 
-To address this, we are planning to introduce **Access Control** in the future, allowing you to grant selected marketplace vendors or specific developer accounts access to your premium extensions and test tags.
+To address this, we are planning to introduce **Access Control** in the future, allowing you to grant selected marketplace vendors or specific developer accounts access to your paid extensions and test tags.
 
-We welcome your feedback on how you’d like to manage and share your premium extensions and tests. Please feel free to provide suggestions, use cases, or requirements.
+We welcome your feedback on how you’d like to manage and share your paid extensions and tests. Please feel free to provide suggestions, use cases, or requirements.

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -10,7 +10,7 @@ For more details, see [Authenticating with QIT](../installation-setup/authentica
 
 ## Downloading paid extensions
 
-Paid extensions require authentication. Similar to the SUT, you **must be the maintainer of the paid extension** you want to include in your test. If you do not own it, you must provide a local source (for example, a ZIP file containing the extension).
+Paid extensions require authentication. Similar to the SUT, you **must be the maintainer of the paid extension** you want to include in your test. If you do not maintain it, you must provide a local source (for example, a ZIP file containing the extension).
 
 Below you’ll find examples of providing local sources.
 

--- a/docs/custom-tests/downloading-extensions-and-tests.md
+++ b/docs/custom-tests/downloading-extensions-and-tests.md
@@ -1,0 +1,71 @@
+# Downloading Extensions and Tests
+
+QIT automatically downloads the extension you are testing (SUT), as well as any additional plugins, dependencies, and their respective custom test tags, if needed.
+
+By default, it fetches stable versions from WooCommerce.com (for premium extensions) or WordPress.org (for free plugins).
+
+## Downloading Premium Extensions
+
+Access to premium extensions on WooCommerce.com is tied to the WooCommerce.com account associated with the QIT Token you obtained during the `qit connect` process. If your account owns and can manage the extension, QIT can download it remotely. Otherwise, you must provide a local source.
+
+For detailed steps on authenticating with QIT, see Authenticating with QIT.
+
+## Understanding Permissions and Ownership
+
+- **Premium Extensions (WooCommerce.com):**  
+  You must own the extension in your WooCommerce.com account to download it remotely. If you do not have access, QIT will fail to fetch it. In that case, providing a local source (e.g., a development build) ensures the test run can continue.
+
+- **Free Extensions (WordPress.org):**  
+  No special permissions are required. QIT downloads them automatically. You can still provide a local source if you want to test a modified or private version.
+
+- **Not Listed on WooCommerce.com:**  
+  If the extension isn’t available in the marketplace, you must provide a local source.
+
+## The System Under Test (SUT)
+
+- **Premium SUT:** You must own it on WooCommerce.com or provide a local source.
+- **Free SUT:** Automatically fetched; local source optional for testing custom builds.
+- **SUT Not Listed:** Must provide a local source directly.
+
+## Additional Plugins and Dependencies
+
+- **Free (WPORG):** Downloaded automatically.
+- **Premium (WCCOM):** Requires ownership; otherwise provide a local source.
+- **Not Listed:** Provide a local source.
+
+This unified approach ensures that if you lack remote access, you can always fall back on a local source.
+
+## Custom Tests (Test Tags)
+
+- **Remote Tests:** QIT fetches them if you have the required access.
+- **Local Tests:** If remote tags aren’t accessible or don’t exist, provide a local directory or zip.
+- **Conflicts:** If the same tag exists both remotely and locally, QIT warns you and uses the remote version by default.
+
+## Providing Local Sources
+
+To supply a local source, add a `source` attribute in `qit.yml`:
+
+```yaml
+plugins:
+  my-premium-sut:
+    source: ./my-premium-sut.zip
+```
+
+For tests:
+
+```yaml
+plugins:
+  my-plugin:
+    test_tags:
+      - ./local-tests/my-plugin-tests
+```
+
+## Error Handling
+
+- **No Ownership:** QIT reports that it can’t fetch the extension. Provide proper credentials or a local source.
+- **Not Found Remotely:** Check the slug or add a local source.
+- **Local vs Remote (Tests):** QIT warns on conflict; remote is used unless you adjust your setup.
+
+## Installing Plugins and Themes from Other Sources
+
+While QIT works seamlessly with WordPress.org and WooCommerce.com listings—plus local sources—you may need to fetch extensions from other locations like private GitHub repositories or premium marketplaces not directly supported by QIT. In these cases, you can implement **custom handlers** that define how QIT should retrieve and prepare these plugins or themes. For more details and examples, refer to the [Advanced Config Handlers documentation](./../advanced-usage/advanced-config-handlers.md).

--- a/docs/installation-setup/authenticating.md
+++ b/docs/installation-setup/authenticating.md
@@ -1,99 +1,39 @@
-Below is a revised version incorporating a brief explanation about authentication and its relation to extension ownership and access:
+# Authenticating with QIT
 
----
+Before you can start running tests or interacting with QIT's cloud-based services, you need to authenticate the QIT CLI with your WooCommerce Marketplace account. This step ensures that only authorized developers can run tests against their listed extensions.
 
-# Downloading Extensions and Tests
+## Prerequisites
 
-When you run tests with QIT, it automatically attempts to download the main plugin or theme you are testing (referred to as the **System Under Test (SUT)**), as well as any additional plugins, dependencies, and associated custom test tags needed for your scenario. By default, it fetches stable versions of extensions from WooCommerce.com (for premium extensions) or WordPress.org (for free plugins).
+- A WooCommerce.com Partner Developer account.
+- At least one extension listed on the WooCommerce Marketplace.
+- The QIT CLI installed and available on your system. Refer to [Installing the QIT CLI](../installation-setup/cli-installation.md).
 
-If something can’t be accessed remotely due to ownership or listing constraints, you can provide a local directory or zip file as a fallback.
+## Generating a QIT token
 
-## Authentication and Access
+1. Run:
 
-Access to premium extensions on WooCommerce.com is tied to the WooCommerce.com account associated with the QIT Token you obtained during the `qit connect` process. If your account owns and can manage the extension, QIT can download it remotely. Otherwise, you must provide a local source.
+   ```qitbash
+   qit connect
+   ```
 
-For detailed steps on authenticating with QIT, see [Authenticating with QIT](../installation-setup/authenticating.md).
+   This command will guide you through the authentication flow. It will open a browser window or prompt you to visit a specific URL, where you must log in with your WooCommerce.com credentials.
 
-## Understanding Permissions and Ownership
+2. Once logged in, the Marketplace will generate a QIT Token. Copy this token.
 
-- **Premium Extensions (WooCommerce.com):**  
-  You must own the extension in your WooCommerce.com account to download it remotely. If you do not have access, QIT will fail to fetch it. In that case, providing a local source (e.g., a development build) ensures the test run can continue.
+3. Return to your terminal and paste the QIT Token when prompted by the CLI.
 
-- **Free Extensions (WordPress.org):**  
-  No special permissions are required. QIT downloads them automatically. You can still provide a local source if you want to test a modified or private version.
+When the process finishes, the CLI will confirm that you are now authenticated.
 
-- **Not Listed on WooCommerce.com:**  
-  If the extension isn’t available in the marketplace, you must provide a local source.
+## Verifying authentication
 
-## The System Under Test (SUT)
+Run:
 
-- **Premium SUT:**  
-  Must be owned on WooCommerce.com or provided locally.
-
-- **Free SUT:**  
-  Automatically fetched; local source optional for testing custom builds.
-
-- **SUT Not Listed:**  
-  Must provide a local source directly.
-
-## Additional Plugins and Dependencies
-
-- **Free (WordPress.org):**  
-  Downloaded automatically.
-
-- **Premium (WooCommerce.com):**  
-  Requires ownership; otherwise provide a local source.
-
-- **Not Listed:**  
-  Provide a local source.
-
-If you lack remote access for any reason, you can always rely on a local source to continue testing.
-
-## Custom Tests (Test Tags)
-
-- **Remote Tests:**  
-  QIT fetches them if your account has the required access.
-
-- **Local Tests:**  
-  If remote tags aren’t accessible or don’t exist, provide a local directory or zip.
-
-- **Conflicts:**  
-  If the same tag exists both remotely and locally, QIT warns you and uses the remote version by default.
-
-## Providing Local Sources
-
-To supply a local source, add a `source` attribute in `qit.yml`:
-
-```yaml
-plugins:
-  my-premium-sut:
-    source: ./my-premium-sut.zip
+```qitbash
+qit extensions
 ```
 
-For tests:
+If authenticated, you`ll see a list of extensions you have access to. This confirms that QIT recognizes your account and grants you the ability to run tests against these extensions.
 
-```yaml
-plugins:
-  my-plugin:
-    test_tags:
-      - ./local-tests/my-plugin-tests
-```
+## Understanding the QIT token
 
-## Error Handling
-
-- **No Ownership:**  
-  QIT reports that it can’t fetch the extension. Provide valid credentials (via `qit connect`) or a local source.
-
-- **Not Found Remotely:**  
-  Check the slug or add a local source.
-
-- **Local vs Remote (Tests):**  
-  QIT warns on conflict; remote is used unless you adjust your setup.
-
-## Installing Plugins and Themes from Other Sources
-
-While QIT works seamlessly with WordPress.org and WooCommerce.com listings—plus local sources—you may need to fetch extensions from other locations such as private GitHub repositories or premium marketplaces not directly supported by QIT. In these cases, you can implement **custom handlers** that define how QIT should retrieve and prepare these plugins or themes. For more details and examples, refer to the [Advanced Config Handlers documentation](./../advanced-usage/advanced-config-handlers.md).
-
----
-
-By understanding how authentication, ownership, and listing status affect remote downloads—and knowing how to provide local sources when needed—you can maintain a flexible and reliable testing setup with QIT.
+The QIT Token you obtain through `qit connect` functions similarly to an application password but is scoped only to QIT actions. If you already have a WordPress Application Password from WooCommerce.com, it will not work with QIT for security reasons. It is required to generate a QIT Token through the `qit connect` flow, as it ensures the correct permissions and scope.

--- a/docs/installation-setup/authenticating.md
+++ b/docs/installation-setup/authenticating.md
@@ -1,39 +1,99 @@
-# Authenticating with QIT
+Below is a revised version incorporating a brief explanation about authentication and its relation to extension ownership and access:
 
-Before you can start running tests or interacting with QIT's cloud-based services, you need to authenticate the QIT CLI with your WooCommerce Marketplace account. This step ensures that only authorized developers can run tests against their listed extensions.
+---
 
-## Prerequisites
+# Downloading Extensions and Tests
 
-- A WooCommerce.com Partner Developer account.
-- At least one extension listed on the WooCommerce Marketplace.
-- The QIT CLI installed and available on your system. Refer to [Installing the QIT CLI](../installation-setup/cli-installation.md).
+When you run tests with QIT, it automatically attempts to download the main plugin or theme you are testing (referred to as the **System Under Test (SUT)**), as well as any additional plugins, dependencies, and associated custom test tags needed for your scenario. By default, it fetches stable versions of extensions from WooCommerce.com (for premium extensions) or WordPress.org (for free plugins).
 
-## Generating a QIT token
+If something can’t be accessed remotely due to ownership or listing constraints, you can provide a local directory or zip file as a fallback.
 
-1. Run:
+## Authentication and Access
 
-   ```qitbash
-   qit connect
-   ```
+Access to premium extensions on WooCommerce.com is tied to the WooCommerce.com account associated with the QIT Token you obtained during the `qit connect` process. If your account owns and can manage the extension, QIT can download it remotely. Otherwise, you must provide a local source.
 
-   This command will guide you through the authentication flow. It will open a browser window or prompt you to visit a specific URL, where you must log in with your WooCommerce.com credentials.
+For detailed steps on authenticating with QIT, see [Authenticating with QIT](../installation-setup/authenticating.md).
 
-2. Once logged in, the Marketplace will generate a QIT Token. Copy this token.
+## Understanding Permissions and Ownership
 
-3. Return to your terminal and paste the QIT Token when prompted by the CLI.
+- **Premium Extensions (WooCommerce.com):**  
+  You must own the extension in your WooCommerce.com account to download it remotely. If you do not have access, QIT will fail to fetch it. In that case, providing a local source (e.g., a development build) ensures the test run can continue.
 
-When the process finishes, the CLI will confirm that you are now authenticated.
+- **Free Extensions (WordPress.org):**  
+  No special permissions are required. QIT downloads them automatically. You can still provide a local source if you want to test a modified or private version.
 
-## Verifying authentication
+- **Not Listed on WooCommerce.com:**  
+  If the extension isn’t available in the marketplace, you must provide a local source.
 
-Run:
+## The System Under Test (SUT)
 
-```qitbash
-qit extensions
+- **Premium SUT:**  
+  Must be owned on WooCommerce.com or provided locally.
+
+- **Free SUT:**  
+  Automatically fetched; local source optional for testing custom builds.
+
+- **SUT Not Listed:**  
+  Must provide a local source directly.
+
+## Additional Plugins and Dependencies
+
+- **Free (WordPress.org):**  
+  Downloaded automatically.
+
+- **Premium (WooCommerce.com):**  
+  Requires ownership; otherwise provide a local source.
+
+- **Not Listed:**  
+  Provide a local source.
+
+If you lack remote access for any reason, you can always rely on a local source to continue testing.
+
+## Custom Tests (Test Tags)
+
+- **Remote Tests:**  
+  QIT fetches them if your account has the required access.
+
+- **Local Tests:**  
+  If remote tags aren’t accessible or don’t exist, provide a local directory or zip.
+
+- **Conflicts:**  
+  If the same tag exists both remotely and locally, QIT warns you and uses the remote version by default.
+
+## Providing Local Sources
+
+To supply a local source, add a `source` attribute in `qit.yml`:
+
+```yaml
+plugins:
+  my-premium-sut:
+    source: ./my-premium-sut.zip
 ```
 
-If authenticated, you`ll see a list of extensions you have access to. This confirms that QIT recognizes your account and grants you the ability to run tests against these extensions.
+For tests:
 
-## Understanding the QIT token
+```yaml
+plugins:
+  my-plugin:
+    test_tags:
+      - ./local-tests/my-plugin-tests
+```
 
-The QIT Token you obtain through `qit connect` functions similarly to an application password but is scoped only to QIT actions. If you already have a WordPress Application Password from WooCommerce.com, it will not work with QIT for security reasons. It is required to generate a QIT Token through the `qit connect` flow, as it ensures the correct permissions and scope.
+## Error Handling
+
+- **No Ownership:**  
+  QIT reports that it can’t fetch the extension. Provide valid credentials (via `qit connect`) or a local source.
+
+- **Not Found Remotely:**  
+  Check the slug or add a local source.
+
+- **Local vs Remote (Tests):**  
+  QIT warns on conflict; remote is used unless you adjust your setup.
+
+## Installing Plugins and Themes from Other Sources
+
+While QIT works seamlessly with WordPress.org and WooCommerce.com listings—plus local sources—you may need to fetch extensions from other locations such as private GitHub repositories or premium marketplaces not directly supported by QIT. In these cases, you can implement **custom handlers** that define how QIT should retrieve and prepare these plugins or themes. For more details and examples, refer to the [Advanced Config Handlers documentation](./../advanced-usage/advanced-config-handlers.md).
+
+---
+
+By understanding how authentication, ownership, and listing status affect remote downloads—and knowing how to provide local sources when needed—you can maintain a flexible and reliable testing setup with QIT.

--- a/sidebars.js
+++ b/sidebars.js
@@ -65,6 +65,7 @@ const sidebars = {
                 'custom-tests/generating-tests',
                 'custom-tests/tagging-tests',
                 'custom-tests/running-tests',
+                'custom-tests/downloading-extensions-and-tests',
                 'custom-tests/understanding-lifecycle',
                 'custom-tests/orchestration',
                 'custom-tests/compatibility-tests',


### PR DESCRIPTION
Add documentation page explaining how QIT handles permissions for downloading Premium extensions and their test tags