### PR TITLE
Cache burst logo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -59,7 +59,7 @@ const config = {
         title: 'Quality Insights Toolkit',
         logo: {
           alt: 'Woo',
-          src: 'img/logo.svg',
+          src: 'img/logo.svg?v=1',
         },
         items: [
           {


### PR DESCRIPTION
Even after clearing the edge cache I had to Ctrl+F5 to see the updated logo, so this PR adds a cache burst parameter to the logo just in case, to avoid any client-side cache as well.