### PR TITLE
Basic docs on extension sets.

### DIFF
--- a/docs/managed-tests/activation.md
+++ b/docs/managed-tests/activation.md
@@ -80,6 +80,10 @@ Replace `your-extension` with the slug of your plugin.
 
 Some plugins might need an actual live site URL to work properly, such as payment gateways and SaaS. For those, you can use our [built-in tunnel feature](../environment/tunnel.md) to test these plugins.
 
+## Canonical compatibility check in the WooCommerce Marketplace
+
+The WooCommerce Marketplace will automatically run an activation test using the [`compatibility` extension set](extension-sets) upon new submission or update. You will see the results in the list of tests under `Activation (canonical compatibility check)`. Currently this test is informational only, and will not block a submission or an update.
+
 ## What to do if it fails
 
 If your Activation test fails:

--- a/docs/managed-tests/extension-sets.md
+++ b/docs/managed-tests/extension-sets.md
@@ -19,7 +19,7 @@ Extension sets can be utilized with [Woo E2E](woo-e2e), [Woo API](woo-api), and 
 - [WooCommerce Shipping](https://woocommerce.com/products/shipping/)
 - [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/)
 - [WooCommerce Composite Products](https://woocommerce.com/products/composite-products/)
-- [WooCommerce Services](https://woocommerce.com/products/tax/)
+- [WooCommerce Tax](https://woocommerce.com/products/tax/)
 - [WooCommerce Google Analytics Integration](https://wordpress.org/plugins/woocommerce-google-analytics-integration/)
 - [MailPoet](https://wordpress.org/plugins/mailpoet/)
 - [Jetpack](https://wordpress.org/plugins/jetpack/)

--- a/docs/managed-tests/extension-sets.md
+++ b/docs/managed-tests/extension-sets.md
@@ -4,7 +4,7 @@ Extension sets provide a way to run certain managed test types with a predefined
 
 ## Compatible test types
 
-Extension sets can be utilized with [Woo E2E](woo-e2e), [Woo API](woo-api), and [activation](activation) tests currently.
+Extension sets can be utilized with [Woo E2E](woo-e2e), [Woo API](woo-api), and [Activation](activation) tests currently.
 
 ## Available extension sets
 

--- a/docs/managed-tests/extension-sets.md
+++ b/docs/managed-tests/extension-sets.md
@@ -1,0 +1,33 @@
+# Extension sets
+
+Extension sets provide a way to run certain managed test types with a predefined set of other extensions included in the environment. This allows for standardized compatibility testing, as well as testing in environments closer to a production WooCommerce store.
+
+## Compatible test types
+
+Extension sets can be utilized with [Woo E2E](woo-e2e), [Woo API](woo-api), and [activation](activation) tests currently.
+
+## Available extension sets
+
+`compatibility` is the only extension set available in production right now. It's designed to contain a selection of typical WooCommerce extensions, including many official extensions:
+- [Gift Cards](https://woocommerce.com/products/gift-cards/)
+- [WooCommerce Product Add-Ons](https://woocommerce.com/products/product-add-ons/)
+- [WooCommerce Min/Max Quantities](https://woocommerce.com/products/min-max-quantities/)
+- [WooCommerce Product Bundles](https://woocommerce.com/products/product-bundles/)
+- [WooCommerce Product Recommendations](https://woocommerce.com/products/product-recommendations/)
+- [WooCommerce Payments](https://woocommerce.com/products/woocommerce-payments/)
+- [AutomateWoo](https://woocommerce.com/products/automatewoo/)
+- [WooCommerce Shipping](https://woocommerce.com/products/shipping/)
+- [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/)
+- [WooCommerce Composite Products](https://woocommerce.com/products/composite-products/)
+- [WooCommerce Services](https://woocommerce.com/products/tax/)
+- [WooCommerce Google Analytics Integration](https://wordpress.org/plugins/woocommerce-google-analytics-integration/)
+- [MailPoet](https://wordpress.org/plugins/mailpoet/)
+- [Jetpack](https://wordpress.org/plugins/jetpack/)
+
+## Running tests with an extension set
+
+All test types that support extension sets support an `--extension_set` argument to the QIT CLI to specify a set to include.
+
+## The WooCommerce Marketplace and extension sets
+
+Currently the WooCommerce Marketplace will automatically run an activation test using the `compatibility` extension set upon new submission or update. You will see the results in the list of tests under `Activation (canonical compatibility check)`. Currently this test is informational only, and will not block a submission or an update.

--- a/docs/managed-tests/extension-sets.md
+++ b/docs/managed-tests/extension-sets.md
@@ -30,4 +30,4 @@ All test types that support extension sets support an `--extension_set` argument
 
 ## The WooCommerce Marketplace and extension sets
 
-Currently the WooCommerce Marketplace will automatically run an activation test using the `compatibility` extension set upon new submission or update. You will see the results in the list of tests under `Activation (canonical compatibility check)`. Currently this test is informational only, and will not block a submission or an update.
+Currently the WooCommerce Marketplace will automatically run an Activation test using the `compatibility` extension set upon new submission or update. You will see the results in the list of tests under `Activation (canonical compatibility check)`. Currently this test is informational only, and will not block a submission or an update.

--- a/docs/support/test-options.md
+++ b/docs/support/test-options.md
@@ -12,6 +12,7 @@ When running tests with QIT, you can specify various options—like WordPress, W
 | PHP Version                  | ✅         | ✅       | ✅       | ❌       | ❌      | ❌         | ❌           |
 | Additional Extensions        | ✅         | ✅       | ✅       | ❌       | ❌      | ❌         | ❌           |
 | Additional WordPress Plugins | ✅         | ✅       | ✅       | ❌       | ❌      | ❌         | ❌           |
+| [Extension sets](../managed-tests/extension-sets) | ✅         | ✅       | ✅       | ❌       | ❌      | ❌         | ❌           |
 
 **Key:**
 - ✅: Option supported by that test type.
@@ -54,6 +55,13 @@ qit run:activation my-extension --plugin=woocommerce --plugin=my-other-plugin
 ```
 
 This ensures compatibility and stable interactions within a controlled environment.
+
+## Extension sets
+
+```qitbash
+qit run:woo-api my-extension --extension_set=compatibility
+```
+Extension sets provide a way to run certain managed test types with a predefined set of other extensions included in the environment. For more information see [their documentation page](../managed-tests/extension-sets).
 
 ## Configuring test options in config files
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -54,6 +54,7 @@ const sidebars = {
                 'managed-tests/malware',
                 'managed-tests/validation',
                 'managed-tests/plugin-check',
+                'managed-tests/extension-sets',
             ],
         },
         {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce.com/issues/22811

This adds some basic documentation on extension sets and their usage. I've put the main page about them under the managed tests, since that's what they apply to at the moment. I've also added a note to the activation test page, since that's the page that people clicking the docs link on an `Activation (canonical compatibility result)` will arrive at. Finally, I added them to the table of CLI args, with a link to their page, plus a section like the other args with an example command and a bit more info.

ChatGPT turned the list of slugs by marketplace from the code into the markdown list of extension titles and links, which was cool. I clicked through them and it messed up a few of the links, so I've fixed them up manually. Worth double checking them all to make sure the title and link URL are correct.

These are fairly bare bones, so any suggestions on anything that needs expanding would be fine!