### PR TITLE
Added Docker requirement

### DIFF
--- a/docs/installation-setup/cli-installation.md
+++ b/docs/installation-setup/cli-installation.md
@@ -7,6 +7,7 @@ The QIT Command Line Interface (CLI) is your primary tool for running tests loca
 - **PHP 7.2.5 or higher**
 - **Unix-like environment** (Linux, macOS, Windows WSL)
 - **Composer** (for installation and updates)
+- **Docker** (to run the QIT CLI and local environment, you can follow [this guide for the system you're using](https://docs.docker.com/engine/install/))
 
 ## Recommended installation: global via composer
 


### PR DESCRIPTION
This PR adds in a note about Docker being needed a as pre-req for the QIT CLI. This is done as a result of a question that came in where Docker wasn't found when using the CLI:

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/ddb87a42-9710-4dde-9b49-7500f20379ba" />
