### PR TITLE
Add Algolia Search and tweak sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,7 +84,36 @@ const config = {
         darkTheme: prismThemes.dracula,
         additionalLanguages: ['php', 'bash', 'json', 'yaml', 'makefile'],
       },
+      algolia: {
+        // The application ID provided by Algolia.
+        appId: 'XLDNDE9LL2',
+        // Public API key: it is safe to commit it.
+        apiKey: '29c11bf5cd152f048721ec14a3adeffd',
+        indexName: 'qit-woo',
+        contextualSearch: false,
+      },
     }),
+  sitemap: {
+    lastmod: 'date',
+    changefreq: 'weekly',
+    priority: 0.5,
+    ignorePatterns: [],
+    filename: 'sitemap.xml',
+    createSitemapItems: async (params) => {
+      const { defaultCreateSitemapItems, ...rest } = params;
+      const items = await defaultCreateSitemapItems(rest);
+
+      // Force trailing slash on URLs that don't have one:
+      return items
+          .map((item) => {
+            if (!item.url.endsWith('/')) {
+              item.url = `${item.url}/`;
+            }
+            return item;
+          });
+    },
+  },
+
 };
 
 export default config;


### PR DESCRIPTION
This PR adds Algolia search, and tweaks our sitemap to add `/` at the end of URLs to avoid an issue where there's a redirect like this:

```
➜  docs-qit git:(25-04/add-search) ✗ curl -IL https://qit.woo.com/docs/using-qit/notifications-results

HTTP/2 301 
server: nginx
date: Wed, 02 Apr 2025 19:56:49 GMT
content-type: text/html
content-length: 162
location: http://qit.woo.com/docs/using-qit/notifications-results/
strict-transport-security: max-age=31536000
x-ac: 1.gru _atomic_dfw MISS
alt-svc: h3=":443"; ma=86400

HTTP/2 200 
server: nginx
date: Wed, 02 Apr 2025 19:56:49 GMT
content-type: text/html
content-length: 30076
strict-transport-security: max-age=31536000
last-modified: Mon, 31 Mar 2025 19:48:00 GMT
vary: Accept-Encoding
etag: "67eaf170-757c"
x-ac: 4.gru _atomic_dfw MISS
accept-ranges: bytes
alt-svc: h3=":443"; ma=86400

➜  docs-qit git:(25-04/add-search) ✗ curl -IL http://qit.woo.com/docs/using-qit/notifications-results/
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Wed, 02 Apr 2025 19:57:12 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://qit.woo.com/docs/using-qit/notifications-results/
Alt-Svc: h3=":443"; ma=86400

HTTP/2 200 
server: nginx
date: Wed, 02 Apr 2025 19:57:12 GMT
content-type: text/html
content-length: 30076
strict-transport-security: max-age=31536000
last-modified: Mon, 31 Mar 2025 19:48:00 GMT
vary: Accept-Encoding
etag: "67eaf170-757c"
x-ac: 4.gru _atomic_dfw MISS
accept-ranges: bytes
alt-svc: h3=":443"; ma=86400

➜  docs-qit git:(25-04/add-search) ✗ curl -IL https://qit.woo.com/docs/using-qit/notifications-results/
HTTP/2 200 
server: nginx
date: Wed, 02 Apr 2025 19:57:24 GMT
content-type: text/html
content-length: 30076
strict-transport-security: max-age=31536000
last-modified: Mon, 31 Mar 2025 19:48:00 GMT
vary: Accept-Encoding
etag: "67eaf170-757c"
x-ac: 4.gru _atomic_dfw MISS
accept-ranges: bytes
alt-svc: h3=":443"; ma=86400
```