### PR TITLE
Update semgrep exclusion

### DIFF
--- a/docs/managed-tests/security.md
+++ b/docs/managed-tests/security.md
@@ -80,7 +80,7 @@ Occasionally, a rule may flag a scenario that you believe is not genuinely insec
   ```  
   For SemGrep errors, add:  
   ```php
-  // nosemgrep: rule-id
+  // nosemgrep
   ```
   Replace `rule-id` with the relevant SemGrep rule name.
 


### PR DESCRIPTION
Removed the `rule_id` from the example on how to ignore a line in semgrep. This is a limitation within out set up that doesn't allow us to ignore individual rules.