### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
 
       - name: Set up PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1


### PR DESCRIPTION
## Summary

WooCommerce intends to enforce full-length commit SHA pinning for GitHub Actions across the organization. This pins every remote action reference in this repository to the commit currently identified by its existing tag or branch, while retaining that human-readable ref in a comment.

Immutable action references reduce the risk that a moved or compromised upstream ref can silently change the code executed by CI, which narrows the supply-chain compromise surface.

## Validation

- Re-ran the action reference scanner in check mode; zero unpinned remote action references remain.
- Ran `git diff --check` successfully.
- Parsed every changed workflow and composite action file as YAML successfully.

## Changelog

No changelog is needed because this changes workflow/action configuration only and is not shipped to merchants.
